### PR TITLE
카카오 OAuth 로그인 문서화 및 배포 도메인 CORS 보완

### DIFF
--- a/src/main/java/com/team8/damo/controller/AuthController.java
+++ b/src/main/java/com/team8/damo/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.team8.damo.controller;
 
+import com.team8.damo.controller.docs.AuthControllerDocs;
 import com.team8.damo.controller.request.OAuthLoginRequest;
 import com.team8.damo.controller.response.BaseResponse;
 import com.team8.damo.service.response.OAuthLoginResponse;
@@ -20,11 +21,12 @@ import static com.team8.damo.entity.enumeration.TokenType.REFRESH;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
     private final AuthService authService;
 
+    @Override
     @PostMapping("/oauth")
-    public BaseResponse<?> oauth(
+    public BaseResponse<OAuthLoginResponse> oauth(
         HttpServletResponse response,
         @Valid @RequestBody OAuthLoginRequest request
     ) {

--- a/src/main/java/com/team8/damo/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,36 @@
+package com.team8.damo.controller.docs;
+
+import com.team8.damo.controller.request.OAuthLoginRequest;
+import com.team8.damo.controller.response.BaseResponse;
+import com.team8.damo.service.response.OAuthLoginResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "Auth API", description = "인증 관련 API")
+public interface AuthControllerDocs {
+
+    @Operation(
+        summary = "카카오 OAuth 로그인",
+        description = """
+            ### 카카오 OAuth 인가 코드를 통해 로그인합니다.
+            - code: 카카오 인가 코드
+
+            **응답**:
+            - userId: 사용자 ID
+            - onboardingStep: 온보딩 단계 (BASIC, CHARACTERISTIC, DONE)
+
+            **쿠키 설정**:
+            - access_token: 액세스 토큰 (HttpOnly, Secure, SameSite=Lax)
+            - refresh_token: 리프레시 토큰 (HttpOnly, Secure, SameSite=Strict)
+            """
+    )
+    @ApiResponse(responseCode = "200", description = "성공")
+    BaseResponse<OAuthLoginResponse> oauth(
+        @Parameter(hidden = true)
+        HttpServletResponse response,
+        OAuthLoginRequest request
+    );
+}

--- a/src/main/java/com/team8/damo/security/SecurityConfig.java
+++ b/src/main/java/com/team8/damo/security/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173", "https://damo.today"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Set-Cookie"));

--- a/src/main/java/com/team8/damo/util/CookieUtil.java
+++ b/src/main/java/com/team8/damo/util/CookieUtil.java
@@ -29,7 +29,7 @@ public class CookieUtil {
             .path("/")
             .sameSite(isAccess ? "Lax" : "Strict")
             .httpOnly(true)
-            .secure(false)
+            .secure(true)
             .maxAge(isAccess ? accessTokenExpTime : refreshTokenExpTime)
             .build();
 


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #51

## 🛠️ 구현 내용

- AuthController에 Swagger 문서 인터페이스를 분리/적용하고 OAuth 응답 타입을 명확화
- 카카오 OAuth 로그인 API 문서와 응답/쿠키 설명을 추가
- 배포 도메인 CORS 허용 및 쿠키 Secure 설정으로 보안 강화