### PR TITLE
그룹 참여 시 사용자가 그룹원으로 저장되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/team8/damo/repository/GroupRepository.java
+++ b/src/main/java/com/team8/damo/repository/GroupRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("update Group g set g.totalMembers = g.totalMembers + 1 where g.id = :groupId")
     void increaseTotalMembers(@Param("groupId") Long groupId);
 }


### PR DESCRIPTION
🎫 관련 이슈

Closes #60 

🛠️ 구현 내용
- 벌크 UPDATE 쿼리 수행 전 명시적으로 플러시 동작하도록 수정