### PR TITLE
알레르기, 선호 음식, 선호 식재료 enum 누락 수정 및 카테고리 초기 데이터 자동 생성

### DIFF
--- a/src/main/java/com/team8/damo/config/DataInitializer.java
+++ b/src/main/java/com/team8/damo/config/DataInitializer.java
@@ -1,0 +1,68 @@
+package com.team8.damo.config;
+
+import com.team8.damo.entity.AllergyCategory;
+import com.team8.damo.entity.LikeFoodCategory;
+import com.team8.damo.entity.LikeIngredientCategory;
+import com.team8.damo.entity.enumeration.AllergyType;
+import com.team8.damo.entity.enumeration.FoodType;
+import com.team8.damo.entity.enumeration.IngredientType;
+import com.team8.damo.repository.AllergyCategoryRepository;
+import com.team8.damo.repository.LikeFoodCategoryRepository;
+import com.team8.damo.repository.LikeIngredientCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final AllergyCategoryRepository allergyCategoryRepository;
+    private final LikeFoodCategoryRepository likeFoodCategoryRepository;
+    private final LikeIngredientCategoryRepository likeIngredientCategoryRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        initAllergyCategoriesIfEmpty();
+        initLikeFoodCategoriesIfEmpty();
+        initLikeIngredientCategoriesIfEmpty();
+    }
+
+    private void initAllergyCategoriesIfEmpty() {
+        if (allergyCategoryRepository.count() > 0) {
+            return;
+        }
+        List<AllergyCategory> categories = Arrays.stream(AllergyType.values())
+            .map(AllergyCategory::new)
+            .toList();
+        allergyCategoryRepository.saveAll(categories);
+    }
+
+    private void initLikeFoodCategoriesIfEmpty() {
+        if (likeFoodCategoryRepository.count() > 0) {
+            return;
+        }
+        List<LikeFoodCategory> categories = Arrays.stream(FoodType.values())
+            .map(LikeFoodCategory::new)
+            .toList();
+        likeFoodCategoryRepository.saveAll(categories);
+    }
+
+    private void initLikeIngredientCategoriesIfEmpty() {
+        if (likeIngredientCategoryRepository.count() > 0) {
+            return;
+        }
+        List<LikeIngredientCategory> categories = Arrays.stream(IngredientType.values())
+            .map(LikeIngredientCategory::new)
+            .toList();
+        likeIngredientCategoryRepository.saveAll(categories);
+    }
+}

--- a/src/main/java/com/team8/damo/entity/enumeration/AllergyType.java
+++ b/src/main/java/com/team8/damo/entity/enumeration/AllergyType.java
@@ -7,27 +7,28 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AllergyType {
     SHRIMP("새우"),
+    OYSTER("굴"),
     CRAB("게"),
+    MUSSEL("홍합"),
     SQUID("오징어"),
+    ABALONE("전복"),
     MACKEREL("고등어"),
     SHELLFISH("조개류"),
-    EGG("달걀"),
-    MILK("우유"),
     BUCKWHEAT("메밀"),
     WHEAT("밀"),
-    PEANUT("땅콩"),
-    SOY("대두"),
+    SOYBEAN("대두"),
     WALNUT("호두"),
+    PEANUT("땅콩"),
     PINE_NUT("잣"),
-    ALMOND("아몬드"),
+    EGG("알류(가금류)"),
+    MILK("우유"),
+    BEEF("쇠고기"),
+    PORK("돼지고기"),
+    CHICKEN("닭고기"),
     PEACH("복숭아"),
     TOMATO("토마토"),
-    PORK("돼지고기"),
-    BEEF("쇠고기"),
-    CHICKEN("닭고기"),
-    SULFITE("아황산류"),
-    SESAME("참깨"),
-    NONE("없음");
+    SULFITES("아황산류");
 
     private final String description;
 }
+

--- a/src/main/java/com/team8/damo/entity/enumeration/FoodType.java
+++ b/src/main/java/com/team8/damo/entity/enumeration/FoodType.java
@@ -10,7 +10,7 @@ public enum FoodType {
     CHINESE("중식"),
     JAPANESE("일식"),
     WESTERN("양식"),
-    OTHER("기타");
+    INTERNATIONAL("세계 음식");
 
     private final String description;
 }

--- a/src/main/java/com/team8/damo/entity/enumeration/IngredientType.java
+++ b/src/main/java/com/team8/damo/entity/enumeration/IngredientType.java
@@ -11,7 +11,7 @@ public enum IngredientType {
     VEGETABLE("채소"),
     DAIRY("유제품"),
     GRAIN("곡물"),
-    FRUIT("과일");
+    POULTRY("가금류");
 
     private final String description;
 }


### PR DESCRIPTION
🎫 관련 이슈

Closes #64 

🛠️ 구현 내용

- 알레르기, 선호 음식, 선호 식재료에 대한 Enum 누락 수정
- DataInitializer를 통해 카테고리가 저장되어 있지 않을 경우 데이터베이스에 저장되도록 추가