### PR TITLE
커스텀 락 AOP와 로컬 락 전략 도입

### DIFF
--- a/src/main/java/com/team8/damo/aop/CustomLock.java
+++ b/src/main/java/com/team8/damo/aop/CustomLock.java
@@ -1,0 +1,31 @@
+package com.team8.damo.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomLock {
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락 획득을 위해 waitTime 만큼 대기
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락을 획득한 이후 leaseTime 이 지나면 락 반환
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/team8/damo/aop/CustomLockAspect.java
+++ b/src/main/java/com/team8/damo/aop/CustomLockAspect.java
@@ -1,0 +1,46 @@
+package com.team8.damo.aop;
+
+import com.team8.damo.lock.LockStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+
+@Slf4j
+@Order(1)
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CustomLockAspect {
+
+    private final LockStrategy lock;
+
+    @Around("@annotation(com.team8.damo.aop.CustomLock)")
+    public Object around(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        CustomLock customLock = method.getAnnotation(CustomLock.class);
+
+        String key = SpelKeyGenerator.getKey(customLock.key(), joinPoint);
+
+        try {
+            return lock.execute(key, customLock, joinPoint);
+        } catch (Exception e) {
+            log.error("Lock Already UnLock {} {}",
+                kv("serviceName", method.getName()),
+                kv("key", key),
+                e
+            );
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/team8/damo/aop/SpelKeyGenerator.java
+++ b/src/main/java/com/team8/damo/aop/SpelKeyGenerator.java
@@ -1,0 +1,31 @@
+package com.team8.damo.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.lang.reflect.Method;
+
+public class SpelKeyGenerator {
+    private static final ExpressionParser parser = new SpelExpressionParser();
+
+    public static String getKey(String spel, JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        Expression expression = parser.parseExpression(spel);
+        Object value = expression.getValue(context);
+
+        return value == null ? "null" : String.format("%s:%s", method.getName(), value.toString());
+    }
+}

--- a/src/main/java/com/team8/damo/lock/LockStrategy.java
+++ b/src/main/java/com/team8/damo/lock/LockStrategy.java
@@ -1,0 +1,8 @@
+package com.team8.damo.lock;
+
+import com.team8.damo.aop.CustomLock;
+import org.aspectj.lang.ProceedingJoinPoint;
+
+public interface LockStrategy {
+    Object execute(String key, CustomLock customLock, ProceedingJoinPoint joinPoint) throws Throwable;
+}

--- a/src/main/java/com/team8/damo/lock/local/LocalLock.java
+++ b/src/main/java/com/team8/damo/lock/local/LocalLock.java
@@ -1,0 +1,45 @@
+package com.team8.damo.lock.local;
+
+import com.team8.damo.aop.CustomLock;
+import com.team8.damo.lock.LockStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LocalLock implements LockStrategy {
+    private final ConcurrentHashMap<String, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AtomicInteger> counterMap = new ConcurrentHashMap<>();
+
+    @Override
+    public Object execute(String key, CustomLock customLock, ProceedingJoinPoint joinPoint) throws Throwable {
+        AtomicInteger counter = counterMap.computeIfAbsent(key, k -> new AtomicInteger(0));
+        counter.incrementAndGet();
+
+        ReentrantLock lock = lockMap.computeIfAbsent(key, k -> new ReentrantLock(true));
+
+        if (!lock.tryLock(customLock.waitTime(), customLock.timeUnit())) {
+            counter.decrementAndGet();
+            throw new RuntimeException();
+        }
+
+        try {
+            log.info("[LocalLock.executor] catch lock key: {}", key);
+            return joinPoint.proceed();
+        } finally {
+            lock.unlock();
+            if (counter.decrementAndGet() == 0) {
+                counterMap.remove(key);
+                lockMap.remove(key);
+            }
+            log.info("[LocalLock.executor] catch unlock key: {}", key);
+        }
+    }
+}

--- a/src/main/java/com/team8/damo/service/GroupService.java
+++ b/src/main/java/com/team8/damo/service/GroupService.java
@@ -1,5 +1,6 @@
 package com.team8.damo.service;
 
+import com.team8.damo.aop.CustomLock;
 import com.team8.damo.entity.*;
 import com.team8.damo.entity.enumeration.AttendanceVoteStatus;
 import com.team8.damo.entity.enumeration.DiningStatus;
@@ -71,6 +72,7 @@ public class GroupService {
     }
 
     @Transactional
+    @CustomLock(key = "#groupId")
     public Long attendGroup(Long userId, Long groupId) {
         if (userGroupRepository.existsByUserIdAndGroupId(userId, groupId)) {
             throw new CustomException(DUPLICATE_GROUP_MEMBER);


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #162

## 🛠️ 구현 내용

- CustomLock 어노테이션과 AOP를 추가해 메서드 단위 락 적용 지원
- 로컬 락 전략을 구현해 키 기반 동시성 제어 및 대기/리스 타임 설정 가능
- 프로필 설정 및 데이터 초기화 범위를 정비하고 그룹 참여 로직 테스트 보강