### PR TITLE
회원 기본 정보 생성/수정 구분 하여 온보딩 스텝 변경

### DIFF
--- a/src/main/java/com/team8/damo/entity/User.java
+++ b/src/main/java/com/team8/damo/entity/User.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.EnumType.STRING;
 
 @Entity
 @Table(
@@ -73,7 +73,7 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(STRING)
     @Column(name = "role_type", length = 20)
-    private RoleType roleType =  RoleType.ROLE_USER;
+    private RoleType roleType = RoleType.ROLE_USER;
 
     public User(Long id, String email, Long providerId) {
         this.id = id;
@@ -116,6 +116,8 @@ public class User extends BaseTimeEntity {
         this.nickname = nickname;
         this.gender = gender;
         this.ageGroup = ageGroup;
-        this.onboardingStep = OnboardingStep.CHARACTERISTIC;
+        if (this.onboardingStep != OnboardingStep.DONE) {
+            this.onboardingStep = OnboardingStep.CHARACTERISTIC;
+        }
     }
 }

--- a/src/main/java/com/team8/damo/service/UserService.java
+++ b/src/main/java/com/team8/damo/service/UserService.java
@@ -1,6 +1,5 @@
 package com.team8.damo.service;
 
-import com.team8.damo.client.AiService;
 import com.team8.damo.entity.*;
 import com.team8.damo.entity.enumeration.AllergyType;
 import com.team8.damo.entity.enumeration.FoodType;
@@ -20,7 +19,6 @@ import com.team8.damo.service.response.UserBasicResponse;
 import com.team8.damo.service.response.UserProfileResponse;
 import com.team8.damo.util.Snowflake;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,8 +43,6 @@ public class UserService {
     private final UserLikeFoodRepository userLikeFoodRepository;
     private final UserLikeIngredientRepository userLikeIngredientRepository;
     private final Snowflake snowflake;
-    private final AiService aiService;
-    private final ApplicationEventPublisher eventPublisher;
     private final CommonEventPublisher commonEventPublisher;
     private final KakaoUtil kakaoUtil;
     private final RefreshTokenRepository refreshTokenRepository;


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #170

## 🛠️ 구현 내용

- 회원 기본 정보 처리 로직을 생성/수정으로 분리해 온보딩 스텝 진행 정확도를 개선