### PR TITLE
번개 모임 & 채팅 엔티티 구현

### DIFF
--- a/src/main/java/com/team8/damo/entity/ChatMessage.java
+++ b/src/main/java/com/team8/damo/entity/ChatMessage.java
@@ -1,0 +1,54 @@
+package com.team8.damo.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "chat_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "lightning_gathering_id", nullable = false)
+    private LightningGathering lightningGathering;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private User user;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder
+    public ChatMessage(Long id, LightningGathering lightningGathering, User user, String content) {
+        this.id = id;
+        this.lightningGathering = lightningGathering;
+        this.user = user;
+        this.content = content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChatMessage that = (ChatMessage) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/team8/damo/entity/LightningGathering.java
+++ b/src/main/java/com/team8/damo/entity/LightningGathering.java
@@ -1,0 +1,56 @@
+package com.team8.damo.entity;
+
+import com.team8.damo.entity.enumeration.GatheringStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "lightning_gathering")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LightningGathering extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private String restaurantId;
+
+    @Column(name = "max_participants", nullable = false)
+    private int maxParticipants;
+
+    @Column(name = "description", length = 30)
+    private String description;
+
+    @Column(name = "gathering_status")
+    @Enumerated(EnumType.STRING)
+    private GatheringStatus gatheringStatus;
+
+    @Builder
+    public LightningGathering(Long id, String restaurantId, int maxParticipants, String description) {
+        this.id = id;
+        this.restaurantId = restaurantId;
+        this.maxParticipants = maxParticipants;
+        this.description = description;
+        this.gatheringStatus = GatheringStatus.OPEN;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LightningGathering that = (LightningGathering) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/team8/damo/entity/LightningGatheringParticipant.java
+++ b/src/main/java/com/team8/damo/entity/LightningGatheringParticipant.java
@@ -1,0 +1,83 @@
+package com.team8.damo.entity;
+
+import com.team8.damo.entity.enumeration.GatheringRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+import static com.team8.damo.entity.enumeration.GatheringRole.*;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "lightning_gathering_participants")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LightningGatheringParticipant extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "lightning_gathering_id", nullable = false)
+    private LightningGathering lightningGathering;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private User user;
+
+    @Enumerated(STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private GatheringRole role;
+
+    @Column(name = "last_read_chat_messages_id")
+    private Long lastReadChatMessageId;
+
+    @Builder
+    public LightningGatheringParticipant(Long id, LightningGathering lightningGathering, User user, GatheringRole role) {
+        this.id = id;
+        this.lightningGathering = lightningGathering;
+        this.user = user;
+        this.role = role;
+    }
+
+    public static LightningGatheringParticipant createLeader(Long id, LightningGathering lightningGathering, User user) {
+        return LightningGatheringParticipant.builder()
+            .id(id)
+            .lightningGathering(lightningGathering)
+            .user(user)
+            .role(LEADER)
+            .build();
+    }
+
+    public static LightningGatheringParticipant createParticipant(Long id, LightningGathering lightningGathering, User user) {
+        return LightningGatheringParticipant.builder()
+            .id(id)
+            .lightningGathering(lightningGathering)
+            .user(user)
+            .role(PARTICIPANT)
+            .build();
+    }
+
+    public void updateLastReadChatMessageId(Long messageId) {
+        this.lastReadChatMessageId = messageId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LightningGatheringParticipant that = (LightningGatheringParticipant) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/team8/damo/entity/ReadStatus.java
+++ b/src/main/java/com/team8/damo/entity/ReadStatus.java
@@ -1,0 +1,35 @@
+package com.team8.damo.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.*;
+
+@Entity
+@Getter
+@Table(name = "read_status")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReadStatus {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "chat_messages_id", nullable = false)
+    private ChatMessage chatMessage;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "lightning_gathering", nullable = false)
+    private LightningGathering lightningGathering;
+
+    @Builder.Default
+    @Column(name = "is_read")
+    private boolean isRead = false;
+}

--- a/src/main/java/com/team8/damo/entity/enumeration/GatheringRole.java
+++ b/src/main/java/com/team8/damo/entity/enumeration/GatheringRole.java
@@ -1,0 +1,13 @@
+package com.team8.damo.entity.enumeration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatheringRole {
+    LEADER("모임장"),
+    PARTICIPANT("참석자");
+
+    private final String description;
+}

--- a/src/main/java/com/team8/damo/entity/enumeration/GatheringStatus.java
+++ b/src/main/java/com/team8/damo/entity/enumeration/GatheringStatus.java
@@ -1,0 +1,14 @@
+package com.team8.damo.entity.enumeration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatheringStatus {
+
+    OPEN("모집 중"),
+    CLOSED("마감");
+
+    private final String description;
+}


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #173 

## 🛠️ 구현 내용

- 번개 모임 채팅 기능을 위한 핵심 도메인 엔티티를 추가해 데이터 모델 기반을 마련
- 참여자 역할과 모임 상태 enum을 도입해 번개 모임 상태 표현을 명확화
- 참여자별 마지막 읽은 메시지 ID 필드를 추가해 미읽음 집계 기준을 확보
- 채팅 메시지와 모임·사용자 연관관계를 정