### PR TITLE
번개 모임 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/team8/damo/controller/LightningController.java
+++ b/src/main/java/com/team8/damo/controller/LightningController.java
@@ -5,6 +5,7 @@ import com.team8.damo.controller.request.LightningCreateRequest;
 import com.team8.damo.controller.response.BaseResponse;
 import com.team8.damo.security.jwt.JwtUserDetails;
 import com.team8.damo.service.LightningService;
+import com.team8.damo.service.response.LightningDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,15 @@ import java.time.LocalDateTime;
 public class LightningController implements LightningControllerDocs {
 
     private final LightningService lightningService;
+
+    @Override
+    @GetMapping("/lightning/{lightningId}")
+    public BaseResponse<LightningDetailResponse> getLightningDetail(
+        @AuthenticationPrincipal JwtUserDetails user,
+        @PathVariable Long lightningId
+    ) {
+        return BaseResponse.ok(lightningService.getLightningDetail(lightningId));
+    }
 
     @Override
     @PostMapping("/lightning/{lightningId}/users/me")

--- a/src/main/java/com/team8/damo/controller/docs/LightningControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/LightningControllerDocs.java
@@ -3,6 +3,7 @@ package com.team8.damo.controller.docs;
 import com.team8.damo.controller.request.LightningCreateRequest;
 import com.team8.damo.controller.response.BaseResponse;
 import com.team8.damo.security.jwt.JwtUserDetails;
+import com.team8.damo.service.response.LightningDetailResponse;
 import com.team8.damo.swagger.annotation.ApiErrorResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,6 +14,19 @@ import static com.team8.damo.exception.errorcode.ErrorCode.*;
 
 @Tag(name = "Lightning Gathering API", description = "번개 모임 관련 API")
 public interface LightningControllerDocs {
+
+    @Operation(
+        summary = "번개 모임 상세 조회",
+        description = "번개 모임의 상세 정보를 조회합니다. 참여자 목록, 식당 위치 정보를 포함합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiErrorResponses({LIGHTNING_NOT_FOUND})
+    BaseResponse<LightningDetailResponse> getLightningDetail(
+        @Parameter(hidden = true)
+        JwtUserDetails user,
+        @Parameter(description = "번개 모임 ID", required = true)
+        Long lightningId
+    );
 
     @Operation(
         summary = "번개 모임 참가",

--- a/src/main/java/com/team8/damo/repository/LightningParticipantRepository.java
+++ b/src/main/java/com/team8/damo/repository/LightningParticipantRepository.java
@@ -12,7 +12,10 @@ import java.util.Optional;
 
 public interface LightningParticipantRepository extends JpaRepository<LightningParticipant, Long> {
 
-    List<LightningParticipant> findAllByLightningId(Long lightningGatheringId);
+    @Query("select lp from LightningParticipant lp " +
+        "join fetch lp.user " +
+        "where lp.lightning.id = :lightningId")
+    List<LightningParticipant> findAllByLightningIdWithUser(Long lightningId);
 
     @EntityGraph(attributePaths = {"lightning"})
     Optional<LightningParticipant> findByLightningIdAndUserId(Long lightningId, Long userId);

--- a/src/main/java/com/team8/damo/service/LightningService.java
+++ b/src/main/java/com/team8/damo/service/LightningService.java
@@ -13,6 +13,7 @@ import com.team8.damo.repository.RestaurantRepository;
 import com.team8.damo.repository.UserRepository;
 import com.team8.damo.service.request.LightningCreateServiceRequest;
 import com.team8.damo.service.response.AvailableLightningResponse;
+import com.team8.damo.service.response.LightningDetailResponse;
 import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.util.Snowflake;
 import lombok.RequiredArgsConstructor;
@@ -159,6 +160,18 @@ public class LightningService {
 
         participant.getLightning().delete();
         lightningParticipantRepository.delete(participant);
+    }
+
+    public LightningDetailResponse getLightningDetail(Long lightningId) {
+        Lightning lightning = lightningRepository.findById(lightningId)
+            .filter(l -> l.getLightningStatus() != LightningStatus.DELETED)
+            .orElseThrow(() -> new CustomException(LIGHTNING_NOT_FOUND));
+
+        List<LightningParticipant> participants = lightningParticipantRepository.findAllByLightningIdWithUser(lightningId);
+
+        Restaurant restaurant = restaurantRepository.findById(lightning.getRestaurantId()).orElse(null);
+
+        return LightningDetailResponse.of(lightning, restaurant, participants);
     }
 
     public List<AvailableLightningResponse> getAvailableLightningList(Long userId) {

--- a/src/main/java/com/team8/damo/service/response/LightningDetailResponse.java
+++ b/src/main/java/com/team8/damo/service/response/LightningDetailResponse.java
@@ -1,0 +1,66 @@
+package com.team8.damo.service.response;
+
+import com.team8.damo.entity.Lightning;
+import com.team8.damo.entity.LightningParticipant;
+import com.team8.damo.entity.Restaurant;
+import com.team8.damo.entity.enumeration.GatheringRole;
+import com.team8.damo.entity.enumeration.LightningStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LightningDetailResponse(
+    Long lightningId,
+    String restaurantName,
+    String longitude,
+    String latitude,
+    String description,
+    LocalDateTime lightningDate,
+    int maxParticipants,
+    int participantsCount,
+    LightningStatus lightningStatus,
+    List<ParticipantResponse> participants
+) {
+
+    public record ParticipantResponse(
+        Long userId,
+        String nickname,
+        GatheringRole role
+    ) {
+
+        public static ParticipantResponse from(LightningParticipant participant) {
+            return new ParticipantResponse(
+                participant.getUser().getId(),
+                participant.getUser().getNickname(),
+                participant.getRole()
+            );
+        }
+    }
+
+    public static LightningDetailResponse of(
+        Lightning lightning,
+        Restaurant restaurant,
+        List<LightningParticipant> participants
+    ) {
+        String restaurantName = restaurant != null ? restaurant.getPlaceName() : "";
+        String longitude = restaurant != null ? restaurant.getLongitude() : "";
+        String latitude = restaurant != null ? restaurant.getLatitude() : "";
+
+        List<ParticipantResponse> participantResponses = participants.stream()
+            .map(ParticipantResponse::from)
+            .toList();
+
+        return new LightningDetailResponse(
+            lightning.getId(),
+            restaurantName,
+            longitude,
+            latitude,
+            lightning.getDescription(),
+            lightning.getLightningDate(),
+            lightning.getMaxParticipants(),
+            participants.size(),
+            lightning.getLightningStatus(),
+            participantResponses
+        );
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #197 

## 🛠️ 구현 내용

- 번개 단건 상세 조회 엔드포인트를 추가해 참여자와 식당 정보를 제공
- LightningDetailResponse DTO를 추가해 상세 응답 모델을 정의
- 사용자 정보 포함 참여자 조회 쿼리를 추가해 상세 조회 성능을 보완
- Swagger 문서를 확장해 상세 조회 흐름을 연결