### PR TITLE
웹소켓 STOMP 엔드포인트 경로와 허용 오리진 수정

### DIFF
--- a/src/main/java/com/team8/damo/config/WebSocketConfig.java
+++ b/src/main/java/com/team8/damo/config/WebSocketConfig.java
@@ -27,8 +27,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-stomp")
-            .setAllowedOriginPatterns("http://localhost:5173", "https://damo.today");
+        registry.addEndpoint("/api/ws-stomp")
+            .setAllowedOriginPatterns("https://localhost:3000", "http://localhost:5173", "https://damo.today");
     }
 
     @Override


### PR DESCRIPTION
- 프론트 API 경로에 맞춰 STOMP 엔드포인트를 /api/ws-stomp 로 변경
- 로컬 HTTPS 개발 환경 접속을 위해 https://localhost:3000 오리진 허용 추가