### PR TITLE
STOMP CONNECT JWT 예외를 에러코드 기반으로 매핑

### DIFF
--- a/src/main/java/com/team8/damo/security/handler/StompErrorHandler.java
+++ b/src/main/java/com/team8/damo/security/handler/StompErrorHandler.java
@@ -1,0 +1,57 @@
+package com.team8.damo.security.handler;
+
+import com.beust.jcommander.internal.Nullable;
+import com.team8.damo.controller.response.BaseResponse;
+import com.team8.damo.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+import tools.jackson.databind.ObjectMapper;
+
+@Component("stompSubProtocolErrorHandler")
+@RequiredArgsConstructor
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(
+        @Nullable Message<byte[]> clientMessage,
+        Throwable ex
+    ) {
+        CustomException ce = unwrapCustomException(ex);
+        if (ce == null) {
+            return
+                super.handleClientMessageProcessingError(clientMessage,
+                    ex);
+        }
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        accessor.setMessage(ce.getMessage());
+        accessor.setNativeHeader("x-http-status", String.valueOf(ce.getHttpStatus().value()));
+        accessor.setNativeHeader("x-error-code", ce.getErrorCode().name());
+        accessor.setLeaveMutable(true);
+
+        byte[] body = toBytes(BaseResponse.fail(ce));
+        return MessageBuilder.createMessage(body, accessor.getMessageHeaders());
+    }
+
+    private CustomException unwrapCustomException(Throwable ex) {
+        Throwable t = ex;
+        while (t != null) {
+            if (t instanceof CustomException ce) return
+                ce;
+            t = t.getCause();
+        }
+        return null;
+    }
+
+    private byte[] toBytes(Object value) {
+        try { return
+            objectMapper.writeValueAsBytes(value); }
+        catch (Exception e) { return new byte[0]; }
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #221

## 🛠️ 구현 내용

- STOMP CONNECT 인증 실패 시 JWT 예외를 ErrorCode로 매핑해 클라이언트 응답 형식을 일관화
- JWT 만료·유효하지 않은 토큰·지원되지 않는 형식·클레임 오류를 세분화해 원인별 처리 정확도 개선
- STOMP 전용 에러 핸들러를 추가해 WebSocket 인증 예외를 REST와 유사한 규격으로 반환하도록 보강