### PR TITLE
테스트 토큰 발급 API 문서화와 경로 허용 범위 확장

### DIFF
--- a/src/main/java/com/team8/damo/controller/AuthController.java
+++ b/src/main/java/com/team8/damo/controller/AuthController.java
@@ -36,6 +36,7 @@ public class AuthController implements AuthControllerDocs {
         return BaseResponse.ok(oAuthLoginResponse);
     }
 
+    @Override
     @PostMapping("/reissue")
     public BaseResponse<Void> reissue(
         HttpServletRequest request,
@@ -48,9 +49,9 @@ public class AuthController implements AuthControllerDocs {
         return BaseResponse.noContent();
     }
 
+    @Override
     @PostMapping("/test")
     public BaseResponse<Void> test(
-        HttpServletRequest request,
         HttpServletResponse response
     ) {
         JwtTokenResponse jwtTokenResponse = authService.test();
@@ -59,12 +60,15 @@ public class AuthController implements AuthControllerDocs {
         return BaseResponse.noContent();
     }
 
+    @Override
     @PostMapping("/test/{userId}")
     public BaseResponse<JwtTokenResponse> test(
         @PathVariable Long userId,
-        HttpServletRequest request,
         HttpServletResponse response
     ) {
-        return BaseResponse.ok(authService.test(userId));
+        JwtTokenResponse jwtTokenResponse = authService.test(userId);
+        CookieUtil.addCookie(response, ACCESS, jwtTokenResponse.accessToken());
+        CookieUtil.addCookie(response, REFRESH, jwtTokenResponse.refreshToken());
+        return BaseResponse.ok(jwtTokenResponse);
     }
 }

--- a/src/main/java/com/team8/damo/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/AuthControllerDocs.java
@@ -2,11 +2,13 @@ package com.team8.damo.controller.docs;
 
 import com.team8.damo.controller.request.OAuthLoginRequest;
 import com.team8.damo.controller.response.BaseResponse;
+import com.team8.damo.service.response.JwtTokenResponse;
 import com.team8.damo.service.response.OAuthLoginResponse;
 import com.team8.damo.swagger.annotation.ApiErrorResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -66,6 +68,48 @@ public interface AuthControllerDocs {
     BaseResponse<?> reissue(
         @Parameter(hidden = true)
         HttpServletRequest request,
+        @Parameter(hidden = true)
+        HttpServletResponse response
+    );
+
+    @Operation(
+        summary = "[테스트] 기본 테스트 토큰 발급",
+        description = """
+            ### 테스트용 JWT 토큰을 발급합니다.
+            - 기본 사용자에 대한 액세스/리프레시 토큰을 발급합니다.
+
+            **쿠키 설정**:
+            - access_token: 액세스 토큰 (HttpOnly, Secure, SameSite=Lax)
+            - refresh_token: 리프레시 토큰 (HttpOnly, Secure, SameSite=Strict)
+            """
+    )
+    @ApiResponse(responseCode = "204", description = "성공")
+    @SecurityRequirements(value = {})
+    BaseResponse<Void> test(
+        @Parameter(hidden = true)
+        HttpServletResponse response
+    );
+
+    @Operation(
+        summary = "[테스트] 특정 사용자 테스트 토큰 발급",
+        description = """
+            ### 특정 사용자에 대한 테스트용 JWT 토큰을 발급합니다.
+            - userId를 지정하여 해당 사용자의 액세스/리프레시 토큰을 발급합니다.
+
+            **응답**:
+            - accessToken: 액세스 토큰
+            - refreshToken: 리프레시 토큰
+
+            **쿠키 설정**:
+            - access_token: 액세스 토큰 (HttpOnly, Secure, SameSite=Lax)
+            - refresh_token: 리프레시 토큰 (HttpOnly, Secure, SameSite=Strict)
+            """
+    )
+    @ApiResponse(responseCode = "200", description = "성공")
+    @SecurityRequirements(value = {})
+    BaseResponse<JwtTokenResponse> test(
+        @Parameter(description = "사용자 ID", required = true, example = "1")
+        Long userId,
         @Parameter(hidden = true)
         HttpServletResponse response
     );

--- a/src/main/java/com/team8/damo/security/SecurityConfig.java
+++ b/src/main/java/com/team8/damo/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
         "/api/v1/auth/oauth",
         "/api/v1/auth/reissue",
         "/api/v1/auth/test",
+        "/api/v1/auth/test/**",
         "/api/v1/s3",
         "/login",
         "/api/healthy",


### PR DESCRIPTION
- AuthControllerDocs에 테스트 토큰 발급 엔드포인트 문서와 보안 예외 설정을 추가
- /api/v1/auth/test/{userId} 응답 시 액세스·리프레시 토큰 쿠키 설정 로직을 반영