### PR TITLE
푸시 알림 설정 변경 API 추가

### DIFF
--- a/src/main/java/com/team8/damo/controller/UserController.java
+++ b/src/main/java/com/team8/damo/controller/UserController.java
@@ -4,6 +4,7 @@ import com.team8.damo.controller.docs.UserControllerDocs;
 import com.team8.damo.controller.request.UserBasicUpdateRequest;
 import com.team8.damo.controller.request.UserCharacteristicsCreateRequest;
 import com.team8.damo.controller.request.ImagePathUpdateRequest;
+import com.team8.damo.controller.request.PushNotificationUpdateRequest;
 import com.team8.damo.controller.request.UserCharacteristicsUpdateRequest;
 import com.team8.damo.controller.response.BaseResponse;
 import com.team8.damo.service.response.UserBasicResponse;
@@ -80,6 +81,15 @@ public class UserController implements UserControllerDocs {
         @Valid @RequestBody UserCharacteristicsUpdateRequest request
     ) {
         userService.updateUserCharacteristics(user.getUserId(), request.toServiceRequest());
+        return BaseResponse.noContent();
+    }
+
+    @PatchMapping("/me/push-notification")
+    public BaseResponse<Void> updatePushNotification(
+        @AuthenticationPrincipal JwtUserDetails user,
+        @Valid @RequestBody PushNotificationUpdateRequest request
+    ) {
+        userService.updatePushNotification(user.getUserId(), request.toServiceRequest());
         return BaseResponse.noContent();
     }
 

--- a/src/main/java/com/team8/damo/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/UserControllerDocs.java
@@ -3,6 +3,7 @@ package com.team8.damo.controller.docs;
 import com.team8.damo.controller.request.UserBasicUpdateRequest;
 import com.team8.damo.controller.request.UserCharacteristicsCreateRequest;
 import com.team8.damo.controller.request.ImagePathUpdateRequest;
+import com.team8.damo.controller.request.PushNotificationUpdateRequest;
 import com.team8.damo.controller.request.UserCharacteristicsUpdateRequest;
 import com.team8.damo.controller.response.BaseResponse;
 import com.team8.damo.service.response.AvailableLightningResponse;
@@ -128,6 +129,21 @@ public interface UserControllerDocs {
         @Parameter(hidden = true)
         JwtUserDetails user,
         UserCharacteristicsUpdateRequest request
+    );
+
+    @Operation(
+        summary = "푸시 알림 설정 변경",
+        description = """
+            ### 푸시 알림 설정을 변경합니다.
+            - isPushNotificationAllowed: 알림 허용 여부 (필수)
+            - fcmToken: FCM 토큰 (알림 허용 시 필수)
+            """
+    )
+    @ApiResponse(responseCode = "204", description = "성공")
+    @ApiErrorResponses({USER_NOT_FOUND, FCM_TOKEN_REQUIRED})
+    BaseResponse<Void> updatePushNotification(
+        @Parameter(hidden = true) JwtUserDetails user,
+        PushNotificationUpdateRequest request
     );
 
     @Operation(

--- a/src/main/java/com/team8/damo/controller/request/PushNotificationUpdateRequest.java
+++ b/src/main/java/com/team8/damo/controller/request/PushNotificationUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.team8.damo.controller.request;
+
+import com.team8.damo.service.request.PushNotificationUpdateServiceRequest;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PushNotificationUpdateRequest {
+
+    private String fcmToken;
+
+    @NotNull(message = "알림 허용 여부는 필수입니다.")
+    private Boolean isPushNotificationAllowed;
+
+    public PushNotificationUpdateServiceRequest toServiceRequest() {
+        return new PushNotificationUpdateServiceRequest(fcmToken, isPushNotificationAllowed);
+    }
+}

--- a/src/main/java/com/team8/damo/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/team8/damo/exception/errorcode/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     DUPLICATE_ALLERGY_CATEGORY(CONFLICT, "알레르기 카테고리가 중복 선택 되었습니다."),
     DUPLICATE_LIKE_FOOD_CATEGORY(CONFLICT, "선호 음식 카테고리가 중복 선택 되었습니다."),
     DUPLICATE_LIKE_INGREDIENT_CATEGORY(CONFLICT, "선호 재료 카테고리가 중복 선택 되었습니다."),
+    FCM_TOKEN_REQUIRED(BAD_REQUEST, "알림을 허용하려면 FCM 토큰이 필요합니다."),
 
     // Group
     GROUP_NOT_FOUND(NOT_FOUND, "그룹을 찾을 수 없습니다."),

--- a/src/main/java/com/team8/damo/service/UserService.java
+++ b/src/main/java/com/team8/damo/service/UserService.java
@@ -14,6 +14,7 @@ import com.team8.damo.exception.errorcode.ErrorCode;
 import com.team8.damo.kakao.KakaoUtil;
 import com.team8.damo.repository.*;
 import com.team8.damo.service.request.UserBasicUpdateServiceRequest;
+import com.team8.damo.service.request.PushNotificationUpdateServiceRequest;
 import com.team8.damo.service.request.UserCharacteristicsCreateServiceRequest;
 import com.team8.damo.service.request.UserCharacteristicsUpdateServiceRequest;
 import com.team8.damo.service.response.UserBasicResponse;
@@ -177,6 +178,20 @@ public class UserService {
 
         refreshTokenRepository.findById(user.getEmail())
             .ifPresent(refreshTokenRepository::delete);
+    }
+
+    @Transactional
+    public void updatePushNotification(Long userId, PushNotificationUpdateServiceRequest request) {
+        User user = findUserBy(userId);
+
+        if (request.isPushNotificationAllowed()) {
+            if (request.fcmToken() == null || request.fcmToken().isBlank()) {
+                throw new CustomException(FCM_TOKEN_REQUIRED);
+            }
+            user.enablePushNotification(request.fcmToken());
+        } else {
+            user.disablePushNotification();
+        }
     }
 
     private User findUserBy(Long userId) {

--- a/src/main/java/com/team8/damo/service/request/PushNotificationUpdateServiceRequest.java
+++ b/src/main/java/com/team8/damo/service/request/PushNotificationUpdateServiceRequest.java
@@ -1,0 +1,6 @@
+package com.team8.damo.service.request;
+
+public record PushNotificationUpdateServiceRequest(
+    String fcmToken,
+    boolean isPushNotificationAllowed
+) {}


### PR DESCRIPTION
- 사용자 푸시 알림 허용/비허용 변경 엔드포인트를 추가
- 알림 허용 시 FCM 토큰 필수 검증과 에러 코드를 추가
- 요청 DTO, 서비스 요청 객체, Swagger 문서를 추가