### PR TITLE
STOMP 채널 로그를 정리하고 종료 디버깅 포인트를 추가

### DIFF
--- a/src/main/java/com/team8/damo/event/handler/CreateChatMessageHandler.java
+++ b/src/main/java/com/team8/damo/event/handler/CreateChatMessageHandler.java
@@ -25,12 +25,6 @@ public class CreateChatMessageHandler implements EventHandler<CreateChatMessageE
             payload.lightningId(),
             ChatBroadcastMessage.from(payload))
         );
-
-        log.info("[ChatService.createChatMessage] {} {} {}",
-            kv("messageId", payload.messageId()),
-            kv("lightningId", payload.lightningId()),
-            kv("sender", payload.senderNickname())
-        );
     }
 
     @Override

--- a/src/main/java/com/team8/damo/security/handler/StompJwtChannelInterceptor.java
+++ b/src/main/java/com/team8/damo/security/handler/StompJwtChannelInterceptor.java
@@ -86,8 +86,6 @@ public class StompJwtChannelInterceptor implements ChannelInterceptor {
         if (destination == null)
             throw new AccessDeniedException("Missing destination");
 
-        log.info("[ChannelInterceptor.authorize] userId : {}", user.getUserId());
-
         return user;
     }
 

--- a/src/main/java/com/team8/damo/security/handler/StompSessionDisconnectEventListener.java
+++ b/src/main/java/com/team8/damo/security/handler/StompSessionDisconnectEventListener.java
@@ -7,6 +7,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 @Slf4j
@@ -22,7 +24,13 @@ public class StompSessionDisconnectEventListener {
         Long userId = extractUserId(event);
 
         subscriptionCleanupManager.unregisterAllBySession(userId, sessionId);
-        log.info("STOMP session disconnected. sessionId={}, userId={}", sessionId, userId);
+    }
+
+    @EventListener
+    public void onSessionDisconnectEvent(SessionDisconnectEvent event) {
+        if (event.getCloseStatus().equals(CloseStatus.NORMAL)) {
+            log.debug("[WS_DEBUG] abnormal disconnect");
+        }
     }
 
     private Long extractUserId(SessionDisconnectEvent event) {


### PR DESCRIPTION
- 채팅 브로드캐스트와 인가 인터셉터의 과도한 로그를 제거
- STOMP 세션 종료 이벤트 처리와 디버그 로그 포인트를 분리
- 연결 종료 원인 추적을 위한 종료 상태 로깅 경로를 추가