### PR TITLE
번개 목록 조회 API에 커서 페이지네이션 추가

### DIFF
--- a/src/main/java/com/team8/damo/controller/UserController.java
+++ b/src/main/java/com/team8/damo/controller/UserController.java
@@ -13,6 +13,7 @@ import com.team8.damo.security.jwt.JwtUserDetails;
 import com.team8.damo.service.LightningService;
 import com.team8.damo.service.UserService;
 import com.team8.damo.service.response.AvailableLightningResponse;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.util.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,7 +23,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 
 
@@ -94,17 +94,25 @@ public class UserController implements UserControllerDocs {
     }
 
     @GetMapping("/me/lightning")
-    public BaseResponse<List<LightningResponse>> getParticipantLightningList(
-        @AuthenticationPrincipal JwtUserDetails user
+    public BaseResponse<CursorPageResponse<LightningResponse>> getParticipantLightningList(
+        @AuthenticationPrincipal JwtUserDetails user,
+        @RequestParam(required = false) Long lastLightningId,
+        @RequestParam(defaultValue = "20") int size
     ) {
-        return BaseResponse.ok(lightningService.getParticipantLightningList(user.getUserId(), LocalDateTime.now(), 3));
+        return BaseResponse.ok(lightningService.getParticipantLightningList(
+            user.getUserId(), LocalDateTime.now(), 3, lastLightningId, size
+        ));
     }
 
     @GetMapping("/me/lightning/available")
-    public BaseResponse<List<AvailableLightningResponse>> getAvailableLightningList(
-        @AuthenticationPrincipal JwtUserDetails user
+    public BaseResponse<CursorPageResponse<AvailableLightningResponse>> getAvailableLightningList(
+        @AuthenticationPrincipal JwtUserDetails user,
+        @RequestParam(required = false) Long lastLightningId,
+        @RequestParam(defaultValue = "20") int size
     ) {
-        return BaseResponse.ok(lightningService.getAvailableLightningList(user.getUserId()));
+        return BaseResponse.ok(lightningService.getAvailableLightningList(
+            user.getUserId(), lastLightningId, size
+        ));
     }
 
     @DeleteMapping("/me")

--- a/src/main/java/com/team8/damo/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/UserControllerDocs.java
@@ -7,6 +7,7 @@ import com.team8.damo.controller.request.PushNotificationUpdateRequest;
 import com.team8.damo.controller.request.UserCharacteristicsUpdateRequest;
 import com.team8.damo.controller.response.BaseResponse;
 import com.team8.damo.service.response.AvailableLightningResponse;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.service.response.UserBasicResponse;
 import com.team8.damo.service.response.UserProfileResponse;
@@ -17,8 +18,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import static com.team8.damo.exception.errorcode.ErrorCode.*;
 
@@ -151,6 +151,7 @@ public interface UserControllerDocs {
         description = """
             ### 사용자가 참가중인 번개 모임 목록을 조회합니다.
             - lightningDate 기준 최근 3일 이내의 번개 모임만 반환
+            - 커서 기반 페이지네이션 (최신순, id DESC)
             - lightningId: 번개 모임 ID
             - restaurantName: 식당 이름
             - description: 설명
@@ -162,15 +163,20 @@ public interface UserControllerDocs {
     )
     @ApiResponse(responseCode = "200", description = "성공")
     @ApiErrorResponses({USER_NOT_FOUND})
-    BaseResponse<List<LightningResponse>> getParticipantLightningList(
+    BaseResponse<CursorPageResponse<LightningResponse>> getParticipantLightningList(
         @Parameter(hidden = true)
-        JwtUserDetails user
+        JwtUserDetails user,
+        @Parameter(description = "마지막 번개 모임 ID (다음 페이지 조회 시 사용)")
+        @RequestParam(required = false) Long lastLightningId,
+        @Parameter(description = "페이지 크기 (기본값: 10)")
+        @RequestParam(defaultValue = "10") int size
     );
 
     @Operation(
         summary = "참가하지 않은 전체 번개 목록 조회",
         description = """
             ### 사용자가 참가하지 않은 OPEN 상태의 번개 모임 목록을 조회합니다.
+            - 커서 기반 페이지네이션 (최신순, id DESC)
             - lightningId: 번개 모임 ID
             - restaurantName: 식당 이름
             - description: 설명
@@ -181,9 +187,13 @@ public interface UserControllerDocs {
     )
     @ApiResponse(responseCode = "200", description = "성공")
     @ApiErrorResponses({USER_NOT_FOUND})
-    BaseResponse<List<AvailableLightningResponse>> getAvailableLightningList(
+    BaseResponse<CursorPageResponse<AvailableLightningResponse>> getAvailableLightningList(
         @Parameter(hidden = true)
-        JwtUserDetails user
+        JwtUserDetails user,
+        @Parameter(description = "마지막 번개 모임 ID (다음 페이지 조회 시 사용)")
+        @RequestParam(required = false) Long lastLightningId,
+        @Parameter(description = "페이지 크기 (기본값: 10)")
+        @RequestParam(defaultValue = "10") int size
     );
 
     @Operation(

--- a/src/main/java/com/team8/damo/repository/LightningParticipantRepository.java
+++ b/src/main/java/com/team8/damo/repository/LightningParticipantRepository.java
@@ -1,6 +1,7 @@
 package com.team8.damo.repository;
 
 import com.team8.damo.entity.LightningParticipant;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -33,6 +34,32 @@ public interface LightningParticipantRepository extends JpaRepository<LightningP
     List<LightningParticipant> findLightningByUserIdAndCutoffDate(
         @Param("userId") Long userId,
         @Param("cutoffDate") LocalDateTime cutoffDate
+    );
+
+    @Query(
+        "select lp from LightningParticipant lp " +
+        "join fetch lp.lightning " +
+        "where lp.user.id = :userId and lp.lightning.lightningDate >= :cutoffDate " +
+        "order by lp.lightning.id desc"
+    )
+    List<LightningParticipant> findLightningByUserIdAndCutoffDateWithCursor(
+        @Param("userId") Long userId,
+        @Param("cutoffDate") LocalDateTime cutoffDate,
+        Pageable pageable
+    );
+
+    @Query(
+        "select lp from LightningParticipant lp " +
+        "join fetch lp.lightning " +
+        "where lp.user.id = :userId and lp.lightning.lightningDate >= :cutoffDate " +
+        "and lp.lightning.id < :lastLightningId " +
+        "order by lp.lightning.id desc"
+    )
+    List<LightningParticipant> findLightningByUserIdAndCutoffDateWithCursorAfter(
+        @Param("userId") Long userId,
+        @Param("cutoffDate") LocalDateTime cutoffDate,
+        @Param("lastLightningId") Long lastLightningId,
+        Pageable pageable
     );
 
     List<LightningParticipant> findAllByLightningIdIn(List<Long> lightningIds);

--- a/src/main/java/com/team8/damo/repository/LightningRepository.java
+++ b/src/main/java/com/team8/damo/repository/LightningRepository.java
@@ -2,6 +2,7 @@ package com.team8.damo.repository;
 
 import com.team8.damo.entity.Lightning;
 import com.team8.damo.entity.enumeration.LightningStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,5 +25,37 @@ public interface LightningRepository extends JpaRepository<Lightning, Long> {
     List<Lightning> findAllByStatusAndUserNotParticipating(
         @Param("status") LightningStatus status,
         @Param("userId") Long userId
+    );
+
+    @Query(
+        "SELECT l FROM Lightning l " +
+            "WHERE l.lightningStatus = :status " +
+            "AND NOT EXISTS (" +
+            "SELECT 1 FROM LightningParticipant lp " +
+            "WHERE lp.lightning = l AND lp.user.id = :userId" +
+            ") " +
+            "ORDER BY l.id DESC"
+    )
+    List<Lightning> findAllByStatusAndUserNotParticipatingWithCursor(
+        @Param("status") LightningStatus status,
+        @Param("userId") Long userId,
+        Pageable pageable
+    );
+
+    @Query(
+        "SELECT l FROM Lightning l " +
+            "WHERE l.lightningStatus = :status " +
+            "AND l.id < :lastLightningId " +
+            "AND NOT EXISTS (" +
+            "SELECT 1 FROM LightningParticipant lp " +
+            "WHERE lp.lightning = l AND lp.user.id = :userId" +
+            ") " +
+            "ORDER BY l.id DESC"
+    )
+    List<Lightning> findAllByStatusAndUserNotParticipatingWithCursorAfter(
+        @Param("status") LightningStatus status,
+        @Param("userId") Long userId,
+        @Param("lastLightningId") Long lastLightningId,
+        Pageable pageable
     );
 }

--- a/src/main/java/com/team8/damo/service/LightningService.java
+++ b/src/main/java/com/team8/damo/service/LightningService.java
@@ -14,10 +14,12 @@ import com.team8.damo.repository.*;
 import com.team8.damo.repository.projections.UnreadCount;
 import com.team8.damo.service.request.LightningCreateServiceRequest;
 import com.team8.damo.service.response.AvailableLightningResponse;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.LightningDetailResponse;
 import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.util.Snowflake;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,16 +93,25 @@ public class LightningService {
         return lightning.getId();
     }
 
-    public List<LightningResponse> getParticipantLightningList(Long userId, LocalDateTime currentTime, int cutoff) {
+    public CursorPageResponse<LightningResponse> getParticipantLightningList(
+        Long userId, LocalDateTime currentTime, int cutoff, Long lastLightningId, int size
+    ) {
         findUserBy(userId);
 
         LocalDateTime cutoffDate = currentTime.minusDays(cutoff);
+        PageRequest pageable = PageRequest.of(0, size + 1);
 
-        List<LightningParticipant> lightningParticipants =
-            lightningParticipantRepository.findLightningByUserIdAndCutoffDate(userId, cutoffDate);
+        List<LightningParticipant> lightningParticipants = lastLightningId == null
+            ? lightningParticipantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable)
+            : lightningParticipantRepository.findLightningByUserIdAndCutoffDateWithCursorAfter(userId, cutoffDate, lastLightningId, pageable);
+
+        boolean hasNext = lightningParticipants.size() > size;
+        if (hasNext) {
+            lightningParticipants = lightningParticipants.subList(0, size);
+        }
 
         if (lightningParticipants.isEmpty()) {
-            return List.of();
+            return new CursorPageResponse<>(List.of(), null, false);
         }
 
         List<Long> lightningIds = lightningParticipants.stream()
@@ -118,7 +129,7 @@ public class LightningService {
 
         Map<Long, Integer> unreadCountMap = createUnreadCountMap(userId);
 
-        return lightningParticipants.stream()
+        List<LightningResponse> content = lightningParticipants.stream()
             .map(p -> {
                 Lightning lightning = p.getLightning();
                 return LightningResponse.of(
@@ -130,6 +141,9 @@ public class LightningService {
                 );
             })
             .toList();
+
+        Long nextCursor = hasNext ? content.get(content.size() - 1).lightningId() : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
 
     @Transactional
@@ -182,15 +196,24 @@ public class LightningService {
         return LightningDetailResponse.of(lightning, restaurant, participants);
     }
 
-    public List<AvailableLightningResponse> getAvailableLightningList(Long userId) {
+    public CursorPageResponse<AvailableLightningResponse> getAvailableLightningList(
+        Long userId, Long lastLightningId, int size
+    ) {
         findUserBy(userId);
 
-        List<Lightning> availableLightnings = lightningRepository.findAllByStatusAndUserNotParticipating(
-            LightningStatus.OPEN, userId
-        );
+        PageRequest pageable = PageRequest.of(0, size + 1);
+
+        List<Lightning> availableLightnings = lastLightningId == null
+            ? lightningRepository.findAllByStatusAndUserNotParticipatingWithCursor(LightningStatus.OPEN, userId, pageable)
+            : lightningRepository.findAllByStatusAndUserNotParticipatingWithCursorAfter(LightningStatus.OPEN, userId, lastLightningId, pageable);
+
+        boolean hasNext = availableLightnings.size() > size;
+        if (hasNext) {
+            availableLightnings = availableLightnings.subList(0, size);
+        }
 
         if (availableLightnings.isEmpty()) {
-            return List.of();
+            return new CursorPageResponse<>(List.of(), null, false);
         }
 
         List<Long> lightningIds = availableLightnings.stream()
@@ -206,13 +229,16 @@ public class LightningService {
 
         Map<String, String> restaurantNameMap = createRestaurantNameMap(restaurantIds);
 
-        return availableLightnings.stream()
+        List<AvailableLightningResponse> content = availableLightnings.stream()
             .map(lightning -> AvailableLightningResponse.of(
                 lightning,
                 restaurantNameMap.getOrDefault(lightning.getRestaurantId(), ""),
                 participantsCountMap.getOrDefault(lightning.getId(), 0L).intValue()
             ))
             .toList();
+
+        Long nextCursor = hasNext ? content.get(content.size() - 1).lightningId() : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
 
     @Transactional

--- a/src/test/java/com/team8/damo/service/LightningServiceTest.java
+++ b/src/test/java/com/team8/damo/service/LightningServiceTest.java
@@ -16,6 +16,7 @@ import com.team8.damo.repository.LightningRepository;
 import com.team8.damo.repository.RestaurantRepository;
 import com.team8.damo.repository.UserRepository;
 import com.team8.damo.service.request.LightningCreateServiceRequest;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.util.Snowflake;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -223,8 +225,10 @@ class LightningServiceTest {
         Restaurant restaurant1 = RestaurantFixture.create("restaurant-1", "맛있는 식당");
         Restaurant restaurant2 = RestaurantFixture.create("restaurant-2", "좋은 식당");
 
+        PageRequest pageable = PageRequest.of(0, 11);
+
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(participantRepository.findLightningByUserIdAndCutoffDate(userId, currentTime.minusDays(cutoff)))
+        given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, currentTime.minusDays(cutoff), pageable))
             .willReturn(List.of(participant1, participant2));
         given(participantRepository.findAllByLightningIdIn(List.of(100L, 200L)))
             .willReturn(List.of(participant1, participant2, otherParticipant));
@@ -234,18 +238,20 @@ class LightningServiceTest {
             .willReturn(List.of());
 
         // when
-        List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+        CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
         // then
-        assertThat(result).hasSize(2)
+        assertThat(result.data()).hasSize(2)
             .extracting("lightningId", "restaurantName", "maxParticipants", "participantsCount", "lightningStatus", "myRole", "unreadCount")
             .containsExactlyInAnyOrder(
                 tuple(100L, "맛있는 식당", 4, 2, LightningStatus.OPEN, GatheringRole.LEADER, 0),
                 tuple(200L, "좋은 식당", 4, 1, LightningStatus.OPEN, GatheringRole.PARTICIPANT, 0)
             );
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.nextCursor()).isNull();
 
         then(userRepository).should().findById(userId);
-        then(participantRepository).should().findLightningByUserIdAndCutoffDate(userId, currentTime.minusDays(cutoff));
+        then(participantRepository).should().findLightningByUserIdAndCutoffDateWithCursor(userId, currentTime.minusDays(cutoff), pageable);
     }
 
     @Test
@@ -258,15 +264,18 @@ class LightningServiceTest {
 
         User user = UserFixture.create(userId);
 
+        PageRequest pageable = PageRequest.of(0, 11);
+
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(participantRepository.findLightningByUserIdAndCutoffDate(userId, currentTime.minusDays(cutoff)))
+        given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, currentTime.minusDays(cutoff), pageable))
             .willReturn(List.of());
 
         // when
-        List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+        CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
         // then
-        assertThat(result).isEmpty();
+        assertThat(result.data()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
 
         then(participantRepository).should(never()).findAllByLightningIdIn(any());
         then(restaurantRepository).should(never()).findAllById(any());
@@ -283,11 +292,11 @@ class LightningServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         // when // then
-        assertThatThrownBy(() -> lightningService.getParticipantLightningList(userId, currentTime, cutoff))
+        assertThatThrownBy(() -> lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10))
             .isInstanceOf(CustomException.class)
             .hasFieldOrPropertyWithValue("errorCode", USER_NOT_FOUND);
 
-        then(participantRepository).should(never()).findLightningByUserIdAndCutoffDate(any(), any());
+        then(participantRepository).should(never()).findLightningByUserIdAndCutoffDateWithCursor(any(), any(), any());
     }
 
     @Test
@@ -303,8 +312,10 @@ class LightningServiceTest {
 
         LightningParticipant participant = LightningParticipant.createLeader(1L, lightning, user);
 
+        PageRequest pageable = PageRequest.of(0, 11);
+
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(participantRepository.findLightningByUserIdAndCutoffDate(userId, currentTime.minusDays(cutoff)))
+        given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, currentTime.minusDays(cutoff), pageable))
             .willReturn(List.of(participant));
         given(participantRepository.findAllByLightningIdIn(List.of(100L)))
             .willReturn(List.of(participant));
@@ -314,11 +325,11 @@ class LightningServiceTest {
             .willReturn(List.of());
 
         // when
-        List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+        CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
         // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0))
+        assertThat(result.data()).hasSize(1);
+        assertThat(result.data().get(0))
             .extracting("lightningId", "restaurantName", "unreadCount")
             .contains(100L, "", 0);
     }
@@ -342,8 +353,10 @@ class LightningServiceTest {
 
         Restaurant restaurant = RestaurantFixture.create("restaurant-1", "맛있는 식당");
 
+        PageRequest pageable = PageRequest.of(0, 11);
+
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(participantRepository.findLightningByUserIdAndCutoffDate(userId, currentTime.minusDays(cutoff)))
+        given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, currentTime.minusDays(cutoff), pageable))
             .willReturn(List.of(leader));
         given(participantRepository.findAllByLightningIdIn(List.of(100L)))
             .willReturn(List.of(leader, participant2, participant3));
@@ -353,11 +366,11 @@ class LightningServiceTest {
             .willReturn(List.of());
 
         // when
-        List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+        CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
         // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0))
+        assertThat(result.data()).hasSize(1);
+        assertThat(result.data().get(0))
             .extracting("lightningId", "participantsCount", "myRole", "unreadCount")
             .contains(100L, 3, GatheringRole.LEADER, 0);
     }
@@ -748,8 +761,10 @@ class LightningServiceTest {
             LightningParticipant participant = LightningParticipant.createLeader(1L, lightning, user);
             Restaurant restaurant = RestaurantFixture.create("restaurant-1", "맛있는 식당");
 
+            PageRequest pageable = PageRequest.of(0, 11);
+
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(participantRepository.findLightningByUserIdAndCutoffDate(userId, cutoffDate))
+            given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable))
                 .willReturn(List.of(participant));
             given(participantRepository.findAllByLightningIdIn(List.of(100L)))
                 .willReturn(List.of(participant));
@@ -759,15 +774,15 @@ class LightningServiceTest {
                 .willReturn(List.of());
 
             // when
-            List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+            CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
             // then
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0))
+            assertThat(result.data()).hasSize(1);
+            assertThat(result.data().get(0))
                 .extracting("lightningId", "restaurantName")
                 .contains(100L, "맛있는 식당");
 
-            then(participantRepository).should().findLightningByUserIdAndCutoffDate(userId, cutoffDate);
+            then(participantRepository).should().findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable);
         }
 
         @Test
@@ -781,17 +796,20 @@ class LightningServiceTest {
 
             User user = UserFixture.create(userId);
 
+            PageRequest pageable = PageRequest.of(0, 11);
+
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(participantRepository.findLightningByUserIdAndCutoffDate(userId, cutoffDate))
+            given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable))
                 .willReturn(List.of());
 
             // when
-            List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+            CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
             // then
-            assertThat(result).isEmpty();
+            assertThat(result.data()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
 
-            then(participantRepository).should().findLightningByUserIdAndCutoffDate(userId, cutoffDate);
+            then(participantRepository).should().findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable);
             then(participantRepository).should(never()).findAllByLightningIdIn(any());
         }
 
@@ -810,8 +828,10 @@ class LightningServiceTest {
             LightningParticipant participant = LightningParticipant.createLeader(1L, lightning, user);
             Restaurant restaurant = RestaurantFixture.create("restaurant-1", "맛있는 식당");
 
+            PageRequest pageable = PageRequest.of(0, 11);
+
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(participantRepository.findLightningByUserIdAndCutoffDate(userId, cutoffDate))
+            given(participantRepository.findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable))
                 .willReturn(List.of(participant));
             given(participantRepository.findAllByLightningIdIn(List.of(100L)))
                 .willReturn(List.of(participant));
@@ -821,15 +841,15 @@ class LightningServiceTest {
                 .willReturn(List.of());
 
             // when
-            List<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff);
+            CursorPageResponse<LightningResponse> result = lightningService.getParticipantLightningList(userId, currentTime, cutoff, null, 10);
 
             // then
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0))
+            assertThat(result.data()).hasSize(1);
+            assertThat(result.data().get(0))
                 .extracting("lightningId", "lightningDate")
                 .contains(100L, futureDate);
 
-            then(participantRepository).should().findLightningByUserIdAndCutoffDate(userId, cutoffDate);
+            then(participantRepository).should().findLightningByUserIdAndCutoffDateWithCursor(userId, cutoffDate, pageable);
         }
     }
 }


### PR DESCRIPTION
- 사용자 참가 번개/참여 가능 번개 조회를 CursorPageResponse로 확장
- lastLightningId, size 기반 커서 조회 쿼리와 서비스 페이징 계산 추가
- 사용자 컨트롤러 문서와 LightningServiceTest를 커서 응답 기준으로 수정