### PR TITLE
내 그룹 목록 조회를 커서 페이지네이션으로 개선

### DIFF
--- a/src/main/java/com/team8/damo/controller/GroupController.java
+++ b/src/main/java/com/team8/damo/controller/GroupController.java
@@ -3,6 +3,7 @@ package com.team8.damo.controller;
 import com.team8.damo.controller.request.GroupCreateRequest;
 import com.team8.damo.controller.request.ImagePathUpdateRequest;
 import com.team8.damo.controller.response.BaseResponse;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.GroupDetailResponse;
 import com.team8.damo.security.jwt.JwtUserDetails;
 import com.team8.damo.service.GroupService;
@@ -13,8 +14,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import com.team8.damo.controller.docs.GroupControllerDocs;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,10 +42,12 @@ public class GroupController implements GroupControllerDocs {
 
     @Override
     @GetMapping("/users/me/groups")
-    public BaseResponse<List<UserGroupResponse>> groupList(
-        @AuthenticationPrincipal JwtUserDetails user
+    public BaseResponse<CursorPageResponse<UserGroupResponse>> groupList(
+        @AuthenticationPrincipal JwtUserDetails user,
+        @RequestParam(required = false) Long lastGroupId,
+        @RequestParam(defaultValue = "20") int size
     ) {
-        return BaseResponse.ok(groupService.getGroupList(user.getUserId()));
+        return BaseResponse.ok(groupService.getGroupList(user.getUserId(), lastGroupId, size));
     }
 
     @Override

--- a/src/main/java/com/team8/damo/controller/docs/GroupControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/GroupControllerDocs.java
@@ -3,19 +3,17 @@ package com.team8.damo.controller.docs;
 import com.team8.damo.controller.request.GroupCreateRequest;
 import com.team8.damo.controller.request.ImagePathUpdateRequest;
 import com.team8.damo.controller.response.BaseResponse;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.GroupDetailResponse;
 import com.team8.damo.security.jwt.JwtUserDetails;
 import com.team8.damo.swagger.annotation.ApiErrorResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import com.team8.damo.service.response.UserGroupResponse;
-
-import java.util.List;
 
 import static com.team8.damo.exception.errorcode.ErrorCode.*;
 
@@ -62,10 +60,10 @@ public interface GroupControllerDocs {
     @Operation(
         summary = "내 그룹 목록 조회",
         description = """
-            ### 사용자가 속한 그룹 목록을 조회합니다.
-            - groupId: 그룹 ID
-            - name: 그룹명
-            - introduction: 소개글
+            ### 사용자가 속한 그룹 목록을 커서 페이지네이션으로 조회합니다.
+            - lastGroupId: 이전 페이지의 마지막 그룹 ID (첫 페이지는 생략)
+            - size: 한 페이지에 조회할 개수 (기본값 20)
+            - 응답에 hasNext, nextCursor가 포함됩니다.
             """
     )
     @ApiResponse(
@@ -73,12 +71,16 @@ public interface GroupControllerDocs {
         description = "성공",
         content = @Content(
             mediaType = "application/json",
-            array = @ArraySchema(schema = @Schema(implementation = UserGroupResponse.class))
+            schema = @Schema(implementation = CursorPageResponse.class)
         )
     )
-    BaseResponse<List<UserGroupResponse>> groupList(
+    BaseResponse<CursorPageResponse<UserGroupResponse>> groupList(
         @Parameter(hidden = true)
-        JwtUserDetails user
+        JwtUserDetails user,
+        @Parameter(description = "이전 페이지의 마지막 그룹 ID (첫 페이지는 생략)")
+        Long lastGroupId,
+        @Parameter(description = "한 페이지에 조회할 개수 (기본값 20)")
+        int size
     );
 
     @Operation(

--- a/src/main/java/com/team8/damo/repository/UserGroupRepository.java
+++ b/src/main/java/com/team8/damo/repository/UserGroupRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +17,14 @@ public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
     @EntityGraph(attributePaths = {"group"})
     @Query("select ug from UserGroup ug where ug.user.id = :userId")
     List<UserGroup> findAllByUserIdWithGroup(@Param("userId") Long userId);
+
+    @EntityGraph(attributePaths = {"group"})
+    @Query("select ug from UserGroup ug where ug.user.id = :userId order by ug.group.id desc")
+    List<UserGroup> findAllByUserIdWithGroupCursor(@Param("userId") Long userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"group"})
+    @Query("select ug from UserGroup ug where ug.user.id = :userId and ug.group.id < :lastGroupId order by ug.group.id desc")
+    List<UserGroup> findAllByUserIdWithGroupCursorAfter(@Param("userId") Long userId, @Param("lastGroupId") Long lastGroupId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"group"})
     Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);

--- a/src/main/java/com/team8/damo/service/GroupService.java
+++ b/src/main/java/com/team8/damo/service/GroupService.java
@@ -9,10 +9,12 @@ import com.team8.damo.exception.CustomException;
 import com.team8.damo.repository.*;
 import com.team8.damo.service.request.GroupCreateServiceRequest;
 import com.team8.damo.service.response.GroupDetailResponse;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.UserGroupResponse;
 import com.team8.damo.util.QrCodeGenerator;
 import com.team8.damo.util.Snowflake;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,11 +56,24 @@ public class GroupService {
         // 기존 이미지 삭제
     }
 
-    public List<UserGroupResponse> getGroupList(Long userId) {
-        List<UserGroup> userGroups = userGroupRepository.findAllByUserIdWithGroup(userId);
-        return userGroups.stream()
+    public CursorPageResponse<UserGroupResponse> getGroupList(Long userId, Long lastGroupId, int size) {
+        PageRequest pageable = PageRequest.of(0, size + 1);
+
+        List<UserGroup> userGroups = lastGroupId == null
+            ? userGroupRepository.findAllByUserIdWithGroupCursor(userId, pageable)
+            : userGroupRepository.findAllByUserIdWithGroupCursorAfter(userId, lastGroupId, pageable);
+
+        boolean hasNext = userGroups.size() > size;
+        if (hasNext) {
+            userGroups = userGroups.subList(0, size);
+        }
+
+        List<UserGroupResponse> content = userGroups.stream()
             .map(UserGroupResponse::from)
             .toList();
+
+        Long nextCursor = hasNext ? content.getLast().groupId() : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
 
     public GroupDetailResponse getGroupDetail(Long userId, Long groupId) {

--- a/src/test/java/com/team8/damo/controller/GroupControllerTest.java
+++ b/src/test/java/com/team8/damo/controller/GroupControllerTest.java
@@ -1,6 +1,7 @@
 package com.team8.damo.controller;
 
 import com.team8.damo.service.GroupService;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.GroupDetailResponse;
 import com.team8.damo.service.response.UserGroupResponse;
 import jakarta.validation.Validation;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -297,12 +299,13 @@ class GroupControllerTest {
     @DisplayName("사용자가 속한 그룹 목록을 성공적으로 조회한다.")
     void getGroupList_success() throws Exception {
         // given
-        List<UserGroupResponse> response = List.of(
+        List<UserGroupResponse> data = List.of(
             new UserGroupResponse(100L, "맛집탐방대", "서울 맛집 모임", "https://example.com/group1.jpg"),
             new UserGroupResponse(101L, "카페투어", "카페 탐방 모임", "https://example.com/group2.jpg")
         );
+        CursorPageResponse<UserGroupResponse> response = new CursorPageResponse<>(data, null, false);
 
-        given(groupService.getGroupList(any())).willReturn(response);
+        given(groupService.getGroupList(any(), any(), anyInt())).willReturn(response);
 
         // when // then
         mockMvc.perform(
@@ -311,22 +314,26 @@ class GroupControllerTest {
             )
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data").isArray())
-            .andExpect(jsonPath("$.data.length()").value(2))
-            .andExpect(jsonPath("$.data[0].groupId").value(100L))
-            .andExpect(jsonPath("$.data[0].name").value("맛집탐방대"))
-            .andExpect(jsonPath("$.data[0].introduction").value("서울 맛집 모임"))
-            .andExpect(jsonPath("$.data[1].groupId").value(101L))
-            .andExpect(jsonPath("$.data[1].name").value("카페투어"));
+            .andExpect(jsonPath("$.data.data").isArray())
+            .andExpect(jsonPath("$.data.data.length()").value(2))
+            .andExpect(jsonPath("$.data.data[0].groupId").value(100L))
+            .andExpect(jsonPath("$.data.data[0].name").value("맛집탐방대"))
+            .andExpect(jsonPath("$.data.data[0].introduction").value("서울 맛집 모임"))
+            .andExpect(jsonPath("$.data.data[1].groupId").value(101L))
+            .andExpect(jsonPath("$.data.data[1].name").value("카페투어"))
+            .andExpect(jsonPath("$.data.hasNext").value(false))
+            .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
 
-        then(groupService).should().getGroupList(any());
+        then(groupService).should().getGroupList(any(), any(), anyInt());
     }
 
     @Test
     @DisplayName("속한 그룹이 없으면 빈 목록을 반환한다.")
     void getGroupList_emptyList() throws Exception {
         // given
-        given(groupService.getGroupList(any())).willReturn(List.of());
+        CursorPageResponse<UserGroupResponse> response = new CursorPageResponse<>(List.of(), null, false);
+
+        given(groupService.getGroupList(any(), any(), anyInt())).willReturn(response);
 
         // when // then
         mockMvc.perform(
@@ -335,10 +342,11 @@ class GroupControllerTest {
             )
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data").isArray())
-            .andExpect(jsonPath("$.data.length()").value(0));
+            .andExpect(jsonPath("$.data.data").isArray())
+            .andExpect(jsonPath("$.data.data.length()").value(0))
+            .andExpect(jsonPath("$.data.hasNext").value(false));
 
-        then(groupService).should().getGroupList(any());
+        then(groupService).should().getGroupList(any(), any(), anyInt());
     }
 
     @Test

--- a/src/test/java/com/team8/damo/service/GroupServiceTest.java
+++ b/src/test/java/com/team8/damo/service/GroupServiceTest.java
@@ -9,6 +9,7 @@ import com.team8.damo.fixture.DiningFixture;
 import com.team8.damo.fixture.GroupFixture;
 import com.team8.damo.fixture.UserFixture;
 import com.team8.damo.repository.*;
+import com.team8.damo.service.response.CursorPageResponse;
 import com.team8.damo.service.response.GroupDetailResponse;
 import com.team8.damo.service.response.UserGroupResponse;
 import com.team8.damo.service.request.GroupCreateServiceRequest;
@@ -173,7 +174,7 @@ class GroupServiceTest {
     }
 
     @Test
-    @DisplayName("사용자가 속한 그룹 목록을 성공적으로 조회한다.")
+    @DisplayName("사용자가 속한 그룹 목록을 커서 페이지네이션으로 성공적으로 조회한다.")
     void getGroupList_success() {
         // given
         Long userId = 1L;
@@ -190,22 +191,24 @@ class GroupServiceTest {
             .role(GroupRole.PARTICIPANT)
             .build();
 
-        given(userGroupRepository.findAllByUserIdWithGroup(userId))
+        given(userGroupRepository.findAllByUserIdWithGroupCursor(any(), any()))
             .willReturn(List.of(userGroup1, userGroup2));
 
         // when
-        List<UserGroupResponse> result = groupService.getGroupList(userId);
+        CursorPageResponse<UserGroupResponse> result = groupService.getGroupList(userId, null, 20);
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result)
+        assertThat(result.data()).hasSize(2);
+        assertThat(result.data())
             .extracting("groupId", "name", "introduction")
             .containsExactly(
                 tuple(100L, "맛집탐방대", "서울 맛집 모임"),
                 tuple(101L, "카페투어", "카페 탐방 모임")
             );
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.nextCursor()).isNull();
 
-        then(userGroupRepository).should().findAllByUserIdWithGroup(userId);
+        then(userGroupRepository).should().findAllByUserIdWithGroupCursor(any(), any());
     }
 
     @Test
@@ -214,16 +217,18 @@ class GroupServiceTest {
         // given
         Long userId = 1L;
 
-        given(userGroupRepository.findAllByUserIdWithGroup(userId))
+        given(userGroupRepository.findAllByUserIdWithGroupCursor(any(), any()))
             .willReturn(List.of());
 
         // when
-        List<UserGroupResponse> result = groupService.getGroupList(userId);
+        CursorPageResponse<UserGroupResponse> result = groupService.getGroupList(userId, null, 20);
 
         // then
-        assertThat(result).isEmpty();
+        assertThat(result.data()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.nextCursor()).isNull();
 
-        then(userGroupRepository).should().findAllByUserIdWithGroup(userId);
+        then(userGroupRepository).should().findAllByUserIdWithGroupCursor(any(), any());
     }
 
     @Test


### PR DESCRIPTION
- 내 그룹 목록 API 응답에 hasNext, nextCursor 정보를 추가
- lastGroupId와 size 기반 커서 조회 로직을 서비스와 저장소에 반영
- 컨트롤러 문서와 컨트롤러/서비스 테스트를 커서 응답 구조로 정비