### PR TITLE
ci-cd-docker.yml에서 트리거 브랜치에서 main 제거

### DIFF
--- a/.github/workflows/ci-cd-docker.yml
+++ b/.github/workflows/ci-cd-docker.yml
@@ -2,9 +2,9 @@ name: Backend CI/CD (Docker)
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
   push:
-    branches: [main, develop]
+    branches: [develop]
 
 env:
   JAVA_VERSION: "21"


### PR DESCRIPTION
### 🛠️ 구현 내용
- main 브래치용 CI/CD에 Code Deploy를 도입함에 따라 현재 ci-cd-docker.yml은 develop 브랜치용으로만 사용
