### PR TITLE
JWT 닉네임 클레임 추가와 프로필 수정 토큰 재발급

### DIFF
--- a/src/main/java/com/team8/damo/controller/ChatMessageController.java
+++ b/src/main/java/com/team8/damo/controller/ChatMessageController.java
@@ -30,7 +30,7 @@ public class ChatMessageController implements ChatMessageControllerDocs {
         ChatMessageRequest request
     ) {
         JwtUserDetails user = (JwtUserDetails) authentication.getPrincipal();
-        chatService.createChatMessage(user.getUserId(), lightningId, request, LocalDateTime.now());
+        chatService.createChatMessage(user.getUserId(), user.getNickname(), lightningId, request, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/com/team8/damo/controller/UserController.java
+++ b/src/main/java/com/team8/damo/controller/UserController.java
@@ -14,8 +14,12 @@ import com.team8.damo.service.LightningService;
 import com.team8.damo.service.UserService;
 import com.team8.damo.service.response.AvailableLightningResponse;
 import com.team8.damo.service.response.CursorPageResponse;
+import com.team8.damo.service.response.JwtTokenResponse;
 import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.util.CookieUtil;
+
+import static com.team8.damo.entity.enumeration.TokenType.ACCESS;
+import static com.team8.damo.entity.enumeration.TokenType.REFRESH;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,9 +48,12 @@ public class UserController implements UserControllerDocs {
     @PatchMapping("/me/basic")
     public BaseResponse<Void> updateBasic(
         @AuthenticationPrincipal JwtUserDetails user,
-        @Valid @RequestBody UserBasicUpdateRequest request
+        @Valid @RequestBody UserBasicUpdateRequest request,
+        HttpServletResponse response
     ) {
-        userService.updateUserBasic(user.getUserId(), request.toServiceRequest());
+        JwtTokenResponse tokenResponse = userService.updateUserBasic(user.getUserId(), request.toServiceRequest());
+        CookieUtil.addCookie(response, ACCESS, tokenResponse.accessToken());
+        CookieUtil.addCookie(response, REFRESH, tokenResponse.refreshToken());
         return BaseResponse.noContent();
     }
 

--- a/src/main/java/com/team8/damo/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/team8/damo/controller/docs/UserControllerDocs.java
@@ -57,7 +57,9 @@ public interface UserControllerDocs {
     BaseResponse<Void> updateBasic(
         @Parameter(hidden = true)
         JwtUserDetails user,
-        UserBasicUpdateRequest request
+        UserBasicUpdateRequest request,
+        @Parameter(hidden = true)
+        HttpServletResponse response
     );
 
     @Operation(

--- a/src/main/java/com/team8/damo/security/jwt/JwtProvider.java
+++ b/src/main/java/com/team8/damo/security/jwt/JwtProvider.java
@@ -32,17 +32,19 @@ public class JwtProvider {
         this.refreshTokenExpTime = refreshTokenExpTime;
     }
 
-    public String createAccessToken(Long userId, String email) {
+    public String createAccessToken(Long userId, String email, String nickname) {
         Claims claims = Jwts.claims();
         claims.put("userId", userId);
         claims.put("email", email);
+        claims.put("nickname", nickname);
         return createToken(claims, accessTokenExpTime);
     }
 
-    public String createRefreshToken(Long userId,  String email) {
+    public String createRefreshToken(Long userId, String email, String nickname) {
         Claims claims = Jwts.claims();
         claims.put("userId", userId);
         claims.put("email", email);
+        claims.put("nickname", nickname);
         return createToken(claims, refreshTokenExpTime);
     }
 
@@ -69,7 +71,8 @@ public class JwtProvider {
         Claims claims = parseClaims(token);
         Long userId = claims.get("userId", Long.class);
         String email = claims.get("email", String.class);
-        UserDetails userDetails = new JwtUserDetails(userId, email);
+        String nickname = claims.get("nickname", String.class);
+        UserDetails userDetails = new JwtUserDetails(userId, email, nickname);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
@@ -81,6 +84,11 @@ public class JwtProvider {
     public String getEmail(String token) {
         Claims claims = parseClaims(token);
         return claims.get("email", String.class);
+    }
+
+    public String getNickname(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("nickname", String.class);
     }
 
     private String createToken(Claims claims, long expTime) {

--- a/src/main/java/com/team8/damo/security/jwt/JwtUserDetails.java
+++ b/src/main/java/com/team8/damo/security/jwt/JwtUserDetails.java
@@ -1,6 +1,5 @@
 package com.team8.damo.security.jwt;
 
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,14 +7,15 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
-@RequiredArgsConstructor
 public class JwtUserDetails implements UserDetails {
     private Long userId;
     private String email;
+    private String nickname;
 
-    public JwtUserDetails(Long userId, String email) {
+    public JwtUserDetails(Long userId, String email, String nickname) {
         this.userId = userId;
         this.email = email;
+        this.nickname = nickname;
     }
 
     @Override
@@ -25,6 +25,10 @@ public class JwtUserDetails implements UserDetails {
 
     public Long getUserId() {
         return userId;
+    }
+
+    public String getNickname() {
+        return nickname;
     }
 
     @Override

--- a/src/main/java/com/team8/damo/service/AuthService.java
+++ b/src/main/java/com/team8/damo/service/AuthService.java
@@ -40,8 +40,8 @@ public class AuthService {
         User user = userRepository.findByEmail(kakaoEmail)
             .orElseGet(() -> join(snowflake.nextId(), kakaoEmail, providerId, isNew));
 
-        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
-        String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail());
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getNickname());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail(), user.getNickname());
         refreshTokenRepository.save(new RefreshToken(user.getEmail(), refreshToken));
 
         return new UserOAuthResponse(isNew, user.getId(), user.getOnboardingStep(), accessToken, refreshToken);
@@ -69,8 +69,11 @@ public class AuthService {
             throw new CustomException(REFRESH_MISMATCH);
         }
 
-        String newAccessToken = jwtProvider.createAccessToken(userId, email);
-        String newRefreshToken = jwtProvider.createRefreshToken(userId, email);
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String newAccessToken = jwtProvider.createAccessToken(userId, email, user.getNickname());
+        String newRefreshToken = jwtProvider.createRefreshToken(userId, email, user.getNickname());
 
         refreshTokenRepository.save(new RefreshToken(email, newRefreshToken));
         return new JwtTokenResponse(newAccessToken, newRefreshToken);
@@ -79,8 +82,8 @@ public class AuthService {
     @Transactional
     public JwtTokenResponse test() {
         String email = "user2@test.com";
-        String accessToken = jwtProvider.createAccessToken(2L, email);
-        String refreshToken = jwtProvider.createRefreshToken(2L, email);
+        String accessToken = jwtProvider.createAccessToken(2L, email, "사용자2");
+        String refreshToken = jwtProvider.createRefreshToken(2L, email, "사용자2");
         refreshTokenRepository.save(new RefreshToken(email, refreshToken));
         return new JwtTokenResponse(accessToken, refreshToken);
     }
@@ -89,8 +92,8 @@ public class AuthService {
     public JwtTokenResponse test(Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        String accessToken = jwtProvider.createAccessToken(userId, user.getEmail());
-        String refreshToken = jwtProvider.createRefreshToken(userId, user.getEmail());
+        String accessToken = jwtProvider.createAccessToken(userId, user.getEmail(), user.getNickname());
+        String refreshToken = jwtProvider.createRefreshToken(userId, user.getEmail(), user.getNickname());
         refreshTokenRepository.save(new RefreshToken(user.getEmail(), refreshToken));
         return new JwtTokenResponse(accessToken, refreshToken);
     }

--- a/src/main/java/com/team8/damo/service/ChatService.java
+++ b/src/main/java/com/team8/damo/service/ChatService.java
@@ -51,11 +51,9 @@ public class ChatService {
     private final UserCacheService userCacheService;
 
     @Transactional
-    public void createChatMessage(Long senderId, Long lightningId, ChatMessageRequest request, LocalDateTime currentTime) {
+    public void createChatMessage(Long senderId, String nickname, Long lightningId, ChatMessageRequest request, LocalDateTime currentTime) {
         User userRef = userRepository.getReferenceById(senderId);
         Lightning lightningRef = lightningRepository.getReferenceById(lightningId);
-
-        UserBasicCache userBasicCache = userCacheService.getUserBasic(senderId);
 
         ChatMessage chatMessage = ChatMessage.builder()
             .id(snowflake.nextId())
@@ -74,7 +72,7 @@ public class ChatService {
                 .chatType(request.chatType())
                 .content(request.content())
                 .createdAt(currentTime)
-                .senderNickname(userBasicCache.nickname())
+                .senderNickname(nickname)
                 .unreadCount(0L)
                 .build()
         );
@@ -342,7 +340,7 @@ public class ChatService {
         List<Long> lastChatMessageIds = lightningParticipantRepository.findParticipantsLastChatMessageIds(lightningId, userId);
         NavigableMap<Long, Long> countMap = lastChatMessageIds.stream()
             .collect(Collectors.groupingBy(
-                Function.identity(),
+                lastChatMessageId -> lastChatMessageId,
                 TreeMap::new,
                 Collectors.counting())
             );
@@ -351,10 +349,6 @@ public class ChatService {
         for (Map.Entry<Long, Long> e : countMap.entrySet()) {
             sum += e.getValue();
             e.setValue(sum);
-        }
-
-        for (Map.Entry<Long, Long> e : countMap.entrySet()) {
-            System.out.println("key: " + e.getKey() + " value: " + e.getValue());
         }
 
         return countMap;

--- a/src/main/java/com/team8/damo/service/UserService.java
+++ b/src/main/java/com/team8/damo/service/UserService.java
@@ -9,14 +9,17 @@ import com.team8.damo.event.EventType;
 import com.team8.damo.event.handler.CommonEventPublisher;
 import com.team8.damo.event.payload.UserPersonaEventPayload;
 import com.team8.damo.event.payload.UserPersonaPayload;
+import com.team8.damo.entity.RefreshToken;
 import com.team8.damo.exception.CustomException;
 import com.team8.damo.exception.errorcode.ErrorCode;
 import com.team8.damo.kakao.KakaoUtil;
 import com.team8.damo.repository.*;
+import com.team8.damo.security.jwt.JwtProvider;
 import com.team8.damo.service.request.UserBasicUpdateServiceRequest;
 import com.team8.damo.service.request.PushNotificationUpdateServiceRequest;
 import com.team8.damo.service.request.UserCharacteristicsCreateServiceRequest;
 import com.team8.damo.service.request.UserCharacteristicsUpdateServiceRequest;
+import com.team8.damo.service.response.JwtTokenResponse;
 import com.team8.damo.service.response.UserBasicResponse;
 import com.team8.damo.service.response.UserProfileResponse;
 import com.team8.damo.util.Snowflake;
@@ -48,9 +51,10 @@ public class UserService {
     private final CommonEventPublisher commonEventPublisher;
     private final KakaoUtil kakaoUtil;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
 
     @Transactional
-    public void updateUserBasic(Long userId, UserBasicUpdateServiceRequest request) {
+    public JwtTokenResponse updateUserBasic(Long userId, UserBasicUpdateServiceRequest request) {
         if (userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
             throw new CustomException(DUPLICATE_NICKNAME);
         }
@@ -59,6 +63,12 @@ public class UserService {
 
         user.updateBasic(request.nickname(), request.gender(), request.ageGroup());
         user.changeImagePath(request.imagePath());
+
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getNickname());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail(), user.getNickname());
+        refreshTokenRepository.save(new RefreshToken(user.getEmail(), refreshToken));
+
+        return new JwtTokenResponse(accessToken, refreshToken);
     }
 
     @Transactional

--- a/src/test/java/com/team8/damo/controller/UserControllerTest.java
+++ b/src/test/java/com/team8/damo/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.team8.damo.entity.enumeration.*;
 import com.team8.damo.fixture.CategoryFixture;
 import com.team8.damo.fixture.UserFixture;
 import com.team8.damo.service.UserService;
+import com.team8.damo.service.response.JwtTokenResponse;
 import com.team8.damo.service.response.UserBasicResponse;
 import com.team8.damo.service.response.UserProfileResponse;
 import jakarta.validation.Validation;
@@ -66,7 +67,8 @@ class UserControllerTest {
             }
             """;
 
-        willDoNothing().given(userService).updateUserBasic(any(), any());
+        given(userService.updateUserBasic(any(), any()))
+            .willReturn(new JwtTokenResponse("access", "refresh"));
 
         // when // then
         mockMvc.perform(

--- a/src/test/java/com/team8/damo/service/AuthServiceTest.java
+++ b/src/test/java/com/team8/damo/service/AuthServiceTest.java
@@ -1,7 +1,9 @@
 package com.team8.damo.service;
 
 import com.team8.damo.entity.RefreshToken;
+import com.team8.damo.entity.User;
 import com.team8.damo.exception.CustomException;
+import com.team8.damo.fixture.UserFixture;
 import com.team8.damo.kakao.KakaoUtil;
 import com.team8.damo.repository.RefreshTokenRepository;
 import com.team8.damo.repository.UserRepository;
@@ -65,13 +67,17 @@ class AuthServiceTest {
             String newAccessToken = "new-access-token";
             String newRefreshToken = "new-refresh-token";
 
+            User user = UserFixture.create(userId);
+            user.updateBasic("테스트닉네임", null, null);
+
             given(jwtProvider.validateToken(refreshToken)).willReturn(true);
             given(jwtProvider.getUserId(refreshToken)).willReturn(userId);
             given(jwtProvider.getEmail(refreshToken)).willReturn(email);
             given(refreshTokenRepository.findById(email))
                 .willReturn(Optional.of(new RefreshToken(email, refreshToken)));
-            given(jwtProvider.createAccessToken(userId, email)).willReturn(newAccessToken);
-            given(jwtProvider.createRefreshToken(userId, email)).willReturn(newRefreshToken);
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(jwtProvider.createAccessToken(userId, email, user.getNickname())).willReturn(newAccessToken);
+            given(jwtProvider.createRefreshToken(userId, email, user.getNickname())).willReturn(newRefreshToken);
 
             // when
             JwtTokenResponse result = authService.reissue(refreshToken);
@@ -84,8 +90,9 @@ class AuthServiceTest {
             then(jwtProvider).should().getUserId(refreshToken);
             then(jwtProvider).should().getEmail(refreshToken);
             then(refreshTokenRepository).should().findById(email);
-            then(jwtProvider).should().createAccessToken(userId, email);
-            then(jwtProvider).should().createRefreshToken(userId, email);
+            then(userRepository).should().findById(userId);
+            then(jwtProvider).should().createAccessToken(userId, email, user.getNickname());
+            then(jwtProvider).should().createRefreshToken(userId, email, user.getNickname());
             then(refreshTokenRepository).should().save(any(RefreshToken.class));
         }
 
@@ -131,7 +138,7 @@ class AuthServiceTest {
             then(jwtProvider).should().getUserId(refreshToken);
             then(jwtProvider).should().getEmail(refreshToken);
             then(refreshTokenRepository).should().findById(email);
-            then(jwtProvider).should(never()).createAccessToken(userId, email);
+            then(jwtProvider).should(never()).createAccessToken(any(), any(), any());
         }
 
         @Test
@@ -158,7 +165,7 @@ class AuthServiceTest {
             then(jwtProvider).should().getUserId(refreshToken);
             then(jwtProvider).should().getEmail(refreshToken);
             then(refreshTokenRepository).should().findById(email);
-            then(jwtProvider).should(never()).createAccessToken(userId, email);
+            then(jwtProvider).should(never()).createAccessToken(any(), any(), any());
         }
     }
 }

--- a/src/test/java/com/team8/damo/service/UserServiceTest.java
+++ b/src/test/java/com/team8/damo/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.team8.damo.service;
 
 import com.team8.damo.client.AiService;
+import com.team8.damo.entity.RefreshToken;
 import com.team8.damo.entity.*;
 import com.team8.damo.entity.enumeration.*;
 import com.team8.damo.event.EventType;
@@ -11,9 +12,11 @@ import com.team8.damo.fixture.CategoryFixture;
 import com.team8.damo.fixture.UserFixture;
 import com.team8.damo.kakao.KakaoUtil;
 import com.team8.damo.repository.*;
+import com.team8.damo.security.jwt.JwtProvider;
 import com.team8.damo.service.request.UserBasicUpdateServiceRequest;
 import com.team8.damo.service.request.UserCharacteristicsCreateServiceRequest;
 import com.team8.damo.service.request.UserCharacteristicsUpdateServiceRequest;
+import com.team8.damo.service.response.JwtTokenResponse;
 import com.team8.damo.service.response.UserBasicResponse;
 import com.team8.damo.service.response.UserProfileResponse;
 import com.team8.damo.util.Snowflake;
@@ -80,6 +83,9 @@ class UserServiceTest {
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
 
     @InjectMocks
     private UserService userService;
@@ -160,17 +166,24 @@ class UserServiceTest {
 
         given(userRepository.existsByNicknameAndIdNot(nickname, userId)).willReturn(false);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(jwtProvider.createAccessToken(eq(userId), any(), eq(nickname))).willReturn("new-access-token");
+        given(jwtProvider.createRefreshToken(eq(userId), any(), eq(nickname))).willReturn("new-refresh-token");
 
         // when
-        userService.updateUserBasic(userId, request);
+        JwtTokenResponse result = userService.updateUserBasic(userId, request);
 
         // then
         assertThat(user.getNickname()).isEqualTo(nickname);
         assertThat(user.getGender()).isEqualTo(gender);
         assertThat(user.getAgeGroup()).isEqualTo(ageGroup);
+        assertThat(result.accessToken()).isEqualTo("new-access-token");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh-token");
 
         then(userRepository).should().existsByNicknameAndIdNot(nickname, userId);
         then(userRepository).should().findById(userId);
+        then(jwtProvider).should().createAccessToken(eq(userId), any(), eq(nickname));
+        then(jwtProvider).should().createRefreshToken(eq(userId), any(), eq(nickname));
+        then(refreshTokenRepository).should().save(any(RefreshToken.class));
     }
 
     @Test
@@ -193,6 +206,7 @@ class UserServiceTest {
 
         then(userRepository).should().existsByNicknameAndIdNot(duplicateNickname, userId);
         then(userRepository).should(never()).findById(userId);
+        then(jwtProvider).should(never()).createAccessToken(any(), any(), any());
     }
 
     @Test
@@ -216,6 +230,7 @@ class UserServiceTest {
 
         then(userRepository).should().existsByNicknameAndIdNot(nickname, userId);
         then(userRepository).should().findById(userId);
+        then(jwtProvider).should(never()).createAccessToken(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
  적용

- Access/Refresh 토큰 생성·인증에 nickname 클레임을 포함
- 사용자 기본정보 수정 API에서 새 토큰을 발급하고 쿠키를 갱신
- 채팅 메시지 생성 시 DB 조회 대신 JWT 닉네임을 전송 페이로드에 사용
- 관련 컨트롤러/서비스 테스트를 변경 시나리오에 맞게 보강