### PR TITLE
Redisson 기반 분산 락 도입으로 그룹 및 번개 참여 동시성 제어 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.apache.commons:commons-pool2'
 
+    // redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:4.3.0'
+
     //Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/team8/damo/aop/DistributedLockAspect.java
+++ b/src/main/java/com/team8/damo/aop/DistributedLockAspect.java
@@ -20,20 +20,20 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 @Aspect
 @Component
 @RequiredArgsConstructor
-public class CustomLockAspect {
+public class DistributedLockAspect {
 
     private final LockStrategy lock;
 
-    @Around("@annotation(com.team8.damo.aop.CustomLock)")
+    @Around("@annotation(com.team8.damo.aop.DistridutedLock)")
     public Object around(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
-        CustomLock customLock = method.getAnnotation(CustomLock.class);
+        DistridutedLock distridutedLock = method.getAnnotation(DistridutedLock.class);
 
-        String key = SpelKeyGenerator.getKey(customLock.key(), joinPoint);
+        String key = SpelKeyGenerator.getKey(distridutedLock.key(), joinPoint);
 
         try {
-            return lock.execute(key, customLock, joinPoint);
+            return lock.execute(key, distridutedLock, joinPoint);
         } catch (Exception e) {
             log.error("Lock Already UnLock {} {}",
                 kv("serviceName", method.getName()),

--- a/src/main/java/com/team8/damo/aop/DistridutedLock.java
+++ b/src/main/java/com/team8/damo/aop/DistridutedLock.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CustomLock {
+public @interface DistridutedLock {
     /**
      * 락의 이름
      */

--- a/src/main/java/com/team8/damo/lock/LockStrategy.java
+++ b/src/main/java/com/team8/damo/lock/LockStrategy.java
@@ -1,8 +1,8 @@
 package com.team8.damo.lock;
 
-import com.team8.damo.aop.CustomLock;
+import com.team8.damo.aop.DistridutedLock;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 public interface LockStrategy {
-    Object execute(String key, CustomLock customLock, ProceedingJoinPoint joinPoint) throws Throwable;
+    Object execute(String key, DistridutedLock distridutedLock, ProceedingJoinPoint joinPoint) throws Throwable;
 }

--- a/src/main/java/com/team8/damo/lock/local/LocalLock.java
+++ b/src/main/java/com/team8/damo/lock/local/LocalLock.java
@@ -1,6 +1,6 @@
 package com.team8.damo.lock.local;
 
-import com.team8.damo.aop.CustomLock;
+import com.team8.damo.aop.DistridutedLock;
 import com.team8.damo.lock.LockStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +19,13 @@ public class LocalLock implements LockStrategy {
     private final ConcurrentHashMap<String, AtomicInteger> counterMap = new ConcurrentHashMap<>();
 
     @Override
-    public Object execute(String key, CustomLock customLock, ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object execute(String key, DistridutedLock distridutedLock, ProceedingJoinPoint joinPoint) throws Throwable {
         AtomicInteger counter = counterMap.computeIfAbsent(key, k -> new AtomicInteger(0));
         counter.incrementAndGet();
 
         ReentrantLock lock = lockMap.computeIfAbsent(key, k -> new ReentrantLock(true));
 
-        if (!lock.tryLock(customLock.waitTime(), customLock.timeUnit())) {
+        if (!lock.tryLock(distridutedLock.waitTime(), distridutedLock.timeUnit())) {
             counter.decrementAndGet();
             throw new RuntimeException();
         }

--- a/src/main/java/com/team8/damo/lock/local/RedisLock.java
+++ b/src/main/java/com/team8/damo/lock/local/RedisLock.java
@@ -1,6 +1,6 @@
 package com.team8.damo.lock.local;
 
-import com.team8.damo.aop.CustomLock;
+import com.team8.damo.aop.DistridutedLock;
 import com.team8.damo.lock.LockStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,11 +21,11 @@ public class RedisLock implements LockStrategy {
     private final RedissonClient redissonClient;
 
     @Override
-    public Object execute(String key, CustomLock customLock, ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object execute(String key, DistridutedLock distridutedLock, ProceedingJoinPoint joinPoint) throws Throwable {
         RLock rLock = redissonClient.getLock(key);
 
         try {
-            boolean available = rLock.tryLock(customLock.waitTime(), customLock.leaseTime(), customLock.timeUnit());
+            boolean available = rLock.tryLock(distridutedLock.waitTime(), distridutedLock.leaseTime(), distridutedLock.timeUnit());
             if (!available) {
                 return false;
             }

--- a/src/main/java/com/team8/damo/service/GroupService.java
+++ b/src/main/java/com/team8/damo/service/GroupService.java
@@ -1,6 +1,6 @@
 package com.team8.damo.service;
 
-import com.team8.damo.aop.CustomLock;
+import com.team8.damo.aop.DistridutedLock;
 import com.team8.damo.entity.*;
 import com.team8.damo.entity.enumeration.AttendanceVoteStatus;
 import com.team8.damo.entity.enumeration.DiningStatus;
@@ -87,7 +87,7 @@ public class GroupService {
     }
 
     @Transactional
-    @CustomLock(key = "#groupId")
+    @DistridutedLock(key = "#groupId")
     public Long attendGroup(Long userId, Long groupId) {
         if (userGroupRepository.existsByUserIdAndGroupId(userId, groupId)) {
             throw new CustomException(DUPLICATE_GROUP_MEMBER);

--- a/src/main/java/com/team8/damo/service/LightningService.java
+++ b/src/main/java/com/team8/damo/service/LightningService.java
@@ -1,6 +1,6 @@
 package com.team8.damo.service;
 
-import com.team8.damo.aop.CustomLock;
+import com.team8.damo.aop.DistridutedLock;
 import com.team8.damo.cache.CacheSpec;
 import com.team8.damo.entity.Lightning;
 import com.team8.damo.entity.LightningParticipant;
@@ -21,7 +21,6 @@ import com.team8.damo.service.response.LightningResponse;
 import com.team8.damo.util.Snowflake;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,7 +46,7 @@ public class LightningService {
     private final CommonEventPublisher commonEventPublisher;
 
     @Transactional
-    @CustomLock(key = "#lightningId")
+    @DistridutedLock(key = "#lightningId")
     @CacheEvict(
         cacheNames = CacheSpec.lightningParticipantCount,
         key = "#lightningId"
@@ -172,7 +171,7 @@ public class LightningService {
     }
 
     @Transactional
-    @CustomLock(key = "#lightningId")
+    @DistridutedLock(key = "#lightningId")
     @CacheEvict(
         cacheNames = CacheSpec.lightningParticipantCount,
         key = "#lightningId"


### PR DESCRIPTION
## 🎫 관련 이슈

Closes #277 

## 🛠️ 구현 내용

- Redisson 기반 LockStrategy를 추가해 다중 인스턴스 환경에서도 동일 키 요청을 직렬화하도록 개선
- 그룹 참여와 번개 참여 기능에 분산 락 어노테이션을 적용해 정원 초과와 중복 참여 방어
- 락 AOP와 어노테이션 명칭을 분산 락 역할에 맞게 정리해 코드 의도를 더 명확하게 개선